### PR TITLE
Add strict expansion mode

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -197,6 +197,10 @@ pub enum ErrorCode {
 	/// (because its IRI scheme matches a term definition and it has no IRI authority).
 	IriConfusedWithPrefix,
 
+	/// Unable to expand a key to a IRI or keyword in strict expansion mode.
+	/// Note: this error is not defined in the JSON-LD API specification.
+	KeyExpansionFailed,
+
 	/// A keyword redefinition has been detected.
 	KeywordRedefinition,
 
@@ -267,6 +271,7 @@ impl ErrorCode {
 			InvalidValueObjectValue => "invalid value object value",
 			InvalidVocabMapping => "invalid vocab mapping",
 			IriConfusedWithPrefix => "IRI confused with prefix",
+			KeyExpansionFailed => "key expansion failed",
 			KeywordRedefinition => "keyword redefinition",
 			LoadingDocumentFailed => "loading document failed",
 			LoadingRemoteContextFailed => "loading remote context failed",
@@ -326,6 +331,7 @@ impl<'a> TryFrom<&'a str> for ErrorCode {
 			"invalid value object value" => Ok(InvalidValueObjectValue),
 			"invalid vocab mapping" => Ok(InvalidVocabMapping),
 			"IRI confused with prefix" => Ok(IriConfusedWithPrefix),
+			"key expansion failed" => Ok(KeyExpansionFailed),
 			"keyword redefinition" => Ok(KeywordRedefinition),
 			"loading document failed" => Ok(LoadingDocumentFailed),
 			"loading remote context failed" => Ok(LoadingRemoteContextFailed),

--- a/src/expansion/element.rs
+++ b/src/expansion/element.rs
@@ -217,6 +217,9 @@ pub fn expand_element<'a, T: Send + Sync + Id, C: Send + Sync + ContextMut<T>, L
 							expanded_entries.push(Entry((*key, expanded_key), value))
 						},
 						Lenient::Unknown(_) => {
+							if options.strict {
+								return Err(ErrorCode::KeyExpansionFailed.into());
+							}
 							warn!("failed to expand key `{}`", key)
 						}
 					}

--- a/src/expansion/mod.rs
+++ b/src/expansion/mod.rs
@@ -39,6 +39,9 @@ pub struct Options {
 	/// Sets the processing mode.
 	pub processing_mode: ProcessingMode,
 
+	/// If true, an error is returned if a value fails to expand. If false, the value is dropped.
+	pub strict: bool,
+
 	/// If set to true, input document entries are processed lexicographically.
 	/// If false, order is not considered in processing.
 	pub ordered: bool


### PR DESCRIPTION
Currently it is possible for values from a JSON-LD document to be dropped during expansion if an object key is not valid in the `@context`. For my use case, [Linked Data Proofs](https://w3c-ccg.github.io/ld-proofs/), I need to catch invalid inputs. I propose to add a "strict expansion" mode in `json-ld`'s expansion options, which when enabled, causes unexpanded terms to trigger an error that would otherwise be dropped.