### PR TITLE
Add semicolon after warn

### DIFF
--- a/src/expansion/element.rs
+++ b/src/expansion/element.rs
@@ -220,7 +220,7 @@ pub fn expand_element<'a, T: Send + Sync + Id, C: Send + Sync + ContextMut<T>, L
 							if options.strict {
 								return Err(ErrorCode::KeyExpansionFailed.into());
 							}
-							warn!("failed to expand key `{}`", key)
+							warn!("failed to expand key `{}`", key);
 						}
 					}
 				}


### PR DESCRIPTION
Work around error appearing in Rust nightly `2021-01-30` (https://github.com/rust-lang/rust/issues/81531, https://github.com/rust-lang/rust/issues/81724)