### PR TITLE
make crate compatible with stable Rust

### DIFF
--- a/examples/custom-ids-iref-enum.rs
+++ b/examples/custom-ids-iref-enum.rs
@@ -1,6 +1,6 @@
 //! This example show how to simplify the `custom-ids.rs` example by using the `iref-enum` crate
 //! to automatically generate the conversions to/from `Iri` using the `IriEnum` derive macro.
-#![feature(proc_macro_hygiene)]
+//#![feature(proc_macro_hygiene)]
 
 extern crate async_std;
 extern crate iref;

--- a/examples/custom-ids.rs
+++ b/examples/custom-ids.rs
@@ -7,7 +7,7 @@
 //! cover the rest. The identifer type (`Id`) is then `Lexicon<Foaf>`.
 //! See the `custom-ids-iref-enum.rs` example to see how to simplify the definition of `Foaf` using
 //! the `iref-enum` crate.
-#![feature(proc_macro_hygiene)]
+//#![feature(proc_macro_hygiene)]
 
 extern crate async_std;
 extern crate iref;

--- a/examples/generate-compact-tests.rs
+++ b/examples/generate-compact-tests.rs
@@ -1,7 +1,7 @@
 //! This bit of code is used to generate the compaction tests for the crate. It it also a good
 //! example of what the crate is capable of.
 
-#![feature(proc_macro_hygiene)]
+//#![feature(proc_macro_hygiene)]
 
 #[macro_use]
 extern crate log;

--- a/examples/generate-expand-tests.rs
+++ b/examples/generate-expand-tests.rs
@@ -1,7 +1,7 @@
 //! This bit of code is used to generate the expansion tests for the crate. It it also a good
 //! example of what the crate is capable of.
 
-#![feature(proc_macro_hygiene)]
+//#![feature(proc_macro_hygiene)]
 
 #[macro_use]
 extern crate log;

--- a/examples/reqwest-loader.rs
+++ b/examples/reqwest-loader.rs
@@ -1,6 +1,6 @@
 //! This example shows how to use the `reqwest::Loader` to download remote documents by
 //! enabeling the `reqwest-loader` feature.
-#![feature(proc_macro_hygiene)]
+//#![feature(proc_macro_hygiene)]
 
 extern crate tokio;
 extern crate iref;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(arbitrary_self_types)]
-
 #[macro_use]
 extern crate log;
 extern crate json;

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -185,8 +185,19 @@ impl<T: Id> Object<T> {
 		}
 	}
 
+	/// If the objat is a language-tagged value,
+	/// Return its associated language.
+	pub fn language(&self) -> Option<LanguageTag> {
+		match self {
+			Object::Value(value) => value.language(),
+			_ => None
+		}
+	}
+}
+
+impl <T: Id> Indexed<Object<T>> {
 	/// Try to convert this object into an unnamed graph.
-	pub fn into_unnamed_graph(self: Indexed<Self>) -> Result<HashSet<Indexed<Object<T>>>, Indexed<Self>> {
+	pub fn into_unnamed_graph(self: Indexed<Object<T>>) -> Result<HashSet<Self>, Self> {
 		let (obj, index) = self.into_parts();
 		match obj {
 			Object::Node(n) => {
@@ -198,16 +209,8 @@ impl<T: Id> Object<T> {
 			obj => Err(Indexed::new(obj, index))
 		}
 	}
-
-	/// If the objat is a language-tagged value,
-	/// Return its associated language.
-	pub fn language(&self) -> Option<LanguageTag> {
-		match self {
-			Object::Value(value) => value.language(),
-			_ => None
-		}
-	}
 }
+
 
 impl<T: Id> Any<T> for Object<T> {
 	fn as_ref(&self) -> Ref<T> {


### PR DESCRIPTION
* `arbitrary_self_types` was really not necessary: see patch in object/mod.rs

* as I understand, `proc_macro_hygiene` adds checks,
  but does not change the semantics, so I commented them out.
