### PR TITLE
Use upstream json crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ reqwest-loader = ["reqwest"]
 [dependencies]
 log = "^0.4"
 mown = "^0.2"
-# json = "^0.12"
-json = { git = "https://github.com/timothee-haudebourg/json-rust", branch = "fix#190" }
+json = "^0.12"
 iref = "^1.4.3"
 futures = "^0.3"
 once_cell = "^1.4"

--- a/src/compaction/node.rs
+++ b/src/compaction/node.rs
@@ -161,7 +161,8 @@ pub async fn compact_indexed_node_with<T: Sync + Send + Id, C: ContextMut<T>, L:
 
 		// For each property and value in compacted value:
 		let mut reverse_map = json::object::Object::new();
-		for (property, value) in reverse_result {
+		for (property, value) in reverse_result.iter_mut() {
+			let value = value.take();
 			// If the term definition for property in the active context indicates that
 			// property is a reverse property
 			if let Some(term_definition) = active_context.get(&property) {


### PR DESCRIPTION
Use [`iter_mut`](https://docs.rs/json/0.12.4/json/object/struct.Object.html#method.iter_mut) and [`take`](https://docs.rs/json/0.12.4/json/enum.JsonValue.html#method.take) instead of [`IntoIterator`](https://github.com/maciejhirsz/json-rust/pull/191). This enables using the upstream version of the `json` crate.