### PR TITLE
Key expansion policies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-ld"
-version = "0.2.0-alpha"
+version = "0.3.0"
 authors = ["Timothée Haudebourg <author@haudebourg.net>"]
 edition = "2018"
 categories = ["web-programming", "database", "data-structures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ json = "^0.12"
 iref = "^2.0.3"
 futures = "^0.3"
 once_cell = "^1.4"
-reqwest = { version = "^0.10", optional = true }
+reqwest = { version = "^0.11", optional = true }
 langtag = "^0.2"
 
 [dev-dependencies]
@@ -29,7 +29,7 @@ async-std = { version = "^1.5", features = ["attributes"] }
 static-iref = "^1.0"
 iref-enum = "^1.2"
 stderrlog = "^0.5"
-tokio = { version = "^0.2", features = ["macros"] }
+tokio = { version = "^1.0", features = ["macros", "rt-multi-thread"] }
 
 [[example]]
 name = "reqwest-loader"

--- a/src/error.rs
+++ b/src/error.rs
@@ -194,7 +194,8 @@ pub enum ErrorCode {
 	/// (because its IRI scheme matches a term definition and it has no IRI authority).
 	IriConfusedWithPrefix,
 
-	/// Unable to expand a key to a IRI or keyword in strict expansion mode.
+	/// Unable to expand a key into a IRI, blank node identifier or keyword
+	/// using the current [key expansion policy](crate::expansion::Policy).
 	/// Note: this error is not defined in the JSON-LD API specification.
 	KeyExpansionFailed,
 

--- a/src/expansion/mod.rs
+++ b/src/expansion/mod.rs
@@ -32,7 +32,7 @@ pub struct Options {
 	pub processing_mode: ProcessingMode,
 
 	/// Term expansion policy.
-	/// 
+	///
 	/// Default is `Policy::Standard`.
 	pub policy: Policy,
 

--- a/src/expansion/mod.rs
+++ b/src/expansion/mod.rs
@@ -31,12 +31,67 @@ pub struct Options {
 	/// Sets the processing mode.
 	pub processing_mode: ProcessingMode,
 
-	/// If true, an error is returned if a value fails to expand. If false, the value is dropped.
-	pub strict: bool,
+	/// Term expansion policy.
+	/// 
+	/// Default is `Policy::Standard`.
+	pub policy: Policy,
 
 	/// If set to true, input document entries are processed lexicographically.
 	/// If false, order is not considered in processing.
 	pub ordered: bool,
+}
+
+/// Key expansion policy.
+///
+/// The default behavior of the expansion algorithm
+/// is to drop keys that are not defined in the context unless:
+///   - there is a vocabulary mapping (`@vocab`) defined in the context; or
+///   - the term contains a `:` character.
+/// In other words, a key that cannot be expanded into an
+/// IRI or a blank node identifier is dropped unless it contains a `:` character.
+///
+/// Sometimes, it is preferable to keep undefined keys in the
+/// expanded document, or to forbid them completely by raising an error.
+/// You can define your preferred policy using one of this type variant
+/// with the [`Options::policy`] field.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Policy {
+	/// Relaxed policy.
+	///
+	/// Undefined keys are always kept in the expanded document
+	/// using the [`Reference::Invalid`] variant.
+	Relaxed,
+
+	/// Standard policy.
+	///
+	/// Every key that cannot be expanded into an
+	/// IRI or a blank node identifier is dropped unless it contains a `:` character.
+	Standard,
+
+	/// Strict policy.
+	///
+	/// Every key that cannot be expanded into an IRI or a blank node identifier
+	/// will raise an error unless the term contains a `:` character.
+	Strict,
+
+	/// Strictest policy.
+	///
+	/// Every key that cannot be expanded into an IRI or a blank node identifier
+	/// will raise an error.
+	Strictest,
+}
+
+impl Policy {
+	/// Returns `true` is the policy is `Strict` or `Strictest`.
+	pub fn is_strict(&self) -> bool {
+		matches!(self, Self::Strict | Self::Strictest)
+	}
+}
+
+impl Default for Policy {
+	fn default() -> Self {
+		Self::Standard
+	}
 }
 
 impl From<Options> for ProcessingOptions {

--- a/src/expansion/node.rs
+++ b/src/expansion/node.rs
@@ -1,5 +1,6 @@
 use super::{
-	expand_element, expand_iri, expand_literal, filter_top_level_item, Entry, Expanded, Options, Policy
+	expand_element, expand_iri, expand_literal, filter_top_level_item, Entry, Expanded, Options,
+	Policy,
 };
 use crate::util::as_array;
 use crate::{
@@ -279,11 +280,14 @@ where
 										Term::Keyword(_) => {
 											return Err(ErrorCode::InvalidReversePropertyMap.into())
 										}
-										Term::Ref(Reference::Invalid(_)) if options.policy == Policy::Strictest => {
+										Term::Ref(Reference::Invalid(_))
+											if options.policy == Policy::Strictest =>
+										{
 											return Err(ErrorCode::KeyExpansionFailed.into())
 										}
 										Term::Ref(reverse_prop)
-											if reverse_prop.as_str().contains(':') || options.policy == Policy::Relaxed =>
+											if reverse_prop.as_str().contains(':')
+												|| options.policy == Policy::Relaxed =>
 										{
 											let reverse_expanded_value = expand_element(
 												active_context,
@@ -332,10 +336,10 @@ where
 										}
 										_ => {
 											if options.policy.is_strict() {
-												return Err(ErrorCode::KeyExpansionFailed.into())
+												return Err(ErrorCode::KeyExpansionFailed.into());
 											}
 											// otherwise the key is just dropped.
-										},
+										}
 									}
 								}
 							} else {
@@ -434,7 +438,9 @@ where
 					return Err(ErrorCode::KeyExpansionFailed.into())
 				}
 
-				Term::Ref(prop) if prop.as_str().contains(':') || options.policy == Policy::Relaxed => {
+				Term::Ref(prop)
+					if prop.as_str().contains(':') || options.policy == Policy::Relaxed =>
+				{
 					let mut container_mapping = Mown::Owned(Container::new());
 
 					let key_definition = active_context.get(key);
@@ -854,10 +860,10 @@ where
 
 				Term::Ref(_) => {
 					if options.policy.is_strict() {
-						return Err(ErrorCode::KeyExpansionFailed.into())
+						return Err(ErrorCode::KeyExpansionFailed.into());
 					}
 					// non-keyword properties that does not include a ':' are skipped.
-				},
+				}
 			}
 		}
 


### PR DESCRIPTION
In response to #13, this PR introduces 4 key expansion policies using the new `Policy` type whose instance is passed to the `expansion::Options` structure:
- `Standard`: every key that cannot be expanded into an IRI or a blank node identifier is dropped unless it contains a `:` character.
- `Relaxed`: undefined keys are always kept in the expanded document.
- `Strict`: every key that cannot be expanded into an IRI or a blank node identifier will raise an error unless the term contains a `:` character.
- `Strictest`: every key that cannot be expanded into an IRI or a blank node identifier will raise an error.

@clehner does this satisfy your needs? Can you try it out?