### PR TITLE
Exclude json-ld-api from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ documentation = "https://docs.rs/json-ld"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 
+exclude = [
+	"/json-ld-api"
+]
+
 [features]
 reqwest-loader = ["reqwest"]
 


### PR DESCRIPTION
The `json-ld-api` git submodule was being included in the crate package. This change is to exclude it from being published, so the crate size can be smaller.

Before:
```
$ tar tzf ~/.cargo/registry/cache/github.com-1ecc6299db9ec823/json-ld-0.4.0.crate |wc -l
2754
$ du -sh ~/.cargo/registry/cache/github.com-1ecc6299db9ec823/json-ld-0.4.0.crate
1.5M    /home/cel/.cargo/registry/cache/github.com-1ecc6299db9ec823/json-ld-0.4.0.crate
```

After (`cargo publish --dry-run`):
```
$ cargo package --list|wc -l
93
$ du -sh target/package/json-ld-0.4.0.crate
92K     target/package/json-ld-0.4.0.crate
```

This means some files referenced by the tests won't be available in the crate. I don't think that is a problem though, since the tests are not run when building the crate as a dependency, as far as I can tell.