### PR TITLE
Expose loader Id struct publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub mod expansion;
 mod id;
 mod indexed;
 mod lang;
-mod loader;
+pub mod loader;
 mod loc;
 mod mode;
 mod null;


### PR DESCRIPTION
This is to make the `loader::Id` struct public which is needed to implement `Loader`. ~~It's exposed with a different name since `Id` is already used for `id::Id`.~~

~~Alternatively, the whole loader module could be made public (`mod loader` → `pub mod loader`).~~

This PR makes the loader module public (`mod loader` → `pub mod loader`).