### PR TITLE
relax content-type detection rules to allow prefix-match

### DIFF
--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -7,7 +7,8 @@ use iref::{Iri, IriBuf};
 use std::collections::HashMap;
 
 pub fn is_json_media_type(ty: &str) -> bool {
-	ty == "application/json" || ty == "application/ld+json"
+	// server can respond with `application/json; charset=UTF-8` that's why we don't compare strings directly
+	ty.starts_with("application/json") || ty.starts_with("application/ld+json")
 }
 
 pub async fn load_remote_json_ld_document<J, P>(url: Iri<'_>, parser: &mut P) -> Result<J, Error>


### PR DESCRIPTION
Hi, thanks for the crate!~

When I tried to use `ReqwestLoader` , I've noticed that it doesn't parse my input at all, because in my case server sends the header like that: `Content-Type: application/ld+json; charset=UTF-8` ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) confirms that it's kinda standard), which is of course won't be matched.
So I've changed `is_json_media_type` to just do `starts_with` matching which should handle both old and new cases.

