### PR TITLE
Resolve ambiguity introduced in rustc nightly 7c4b47696 2022-04-30

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -104,7 +104,7 @@ pub trait Compact<J: JsonSrc, T: Id> {
 		C: Sync + Send,
 		C::LocalContext: Send + Sync + From<L::Output>,
 		L: Sync + Send,
-		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData;
+		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData;
 
 	/// Compact a JSON-LD document into a `K` JSON value with the provided options.
 	///
@@ -124,7 +124,7 @@ pub trait Compact<J: JsonSrc, T: Id> {
 		C: Sync + Send,
 		C::LocalContext: Send + Sync + From<L::Output>,
 		L: Sync + Send,
-		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 	{
 		async move {
 			self.compact_full(
@@ -154,7 +154,7 @@ pub trait Compact<J: JsonSrc, T: Id> {
 		C: Sync + Send,
 		C::LocalContext: Send + Sync + From<L::Output>,
 		L: Sync + Send,
-		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 	{
 		self.compact_with(active_context, loader, Options::default(), meta)
 	}
@@ -184,7 +184,7 @@ pub trait CompactIndexed<J: JsonSrc, T: Id> {
 		C: Sync + Send,
 		C::LocalContext: Send + Sync + From<L::Output>,
 		L: Sync + Send,
-		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData;
+		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData;
 }
 
 impl<J: JsonSrc, T: Sync + Send + Id, V: Sync + Send + CompactIndexed<J, T>> Compact<J, T>
@@ -205,7 +205,7 @@ impl<J: JsonSrc, T: Sync + Send + Id, V: Sync + Send + CompactIndexed<J, T>> Com
 		C: Sync + Send,
 		C::LocalContext: Send + Sync + From<L::Output>,
 		L: Sync + Send,
-		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 	{
 		self.inner().compact_indexed(
 			self.index(),
@@ -238,7 +238,7 @@ impl<J: JsonSrc, T: Sync + Send + Id, N: object::Any<J, T> + Sync + Send> Compac
 		C: Sync + Send,
 		C::LocalContext: Send + Sync + From<L::Output>,
 		L: Sync + Send,
-		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 	{
 		match self.as_ref() {
 			object::Ref::Value(value) => async move {
@@ -321,7 +321,7 @@ impl<J: JsonSrc, T: Sync + Send + Id, N: object::Any<J, T> + Sync + Send> Compac
 					)
 					.await
 				} else {
-					let mut result = K::Object::default();
+					let mut result = <K as generic_json::Json>::Object::default();
 					compact_property::<J, K, _, _, _, _, _, _>(
 						&mut result,
 						Term::Keyword(Keyword::List),
@@ -424,7 +424,7 @@ fn add_value<K: JsonBuild + JsonMut>(
 /// Get the `@value` field of a value object.
 fn value_value<J: JsonClone, K: JsonFrom<J>, T: Id, M>(value: &Value<J, T>, meta: M) -> K
 where
-	M: Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	M: Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 {
 	use crate::object::value::Literal;
 	match value {
@@ -461,7 +461,7 @@ where
 	C: Sync + Send,
 	C::LocalContext: Send + Sync + From<L::Output>,
 	L: Sync + Send,
-	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 {
 	async move {
 		let mut result = Vec::new();
@@ -525,7 +525,7 @@ impl<J: JsonSrc, T: Sync + Send + Id> Compact<J, T> for HashSet<Indexed<Object<J
 		C: Sync + Send,
 		C::LocalContext: Send + Sync + From<L::Output>,
 		L: Sync + Send,
-		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 	{
 		compact_collection_with(
 			self.iter(),

--- a/src/compaction/node.rs
+++ b/src/compaction/node.rs
@@ -29,7 +29,7 @@ where
 	C: Sync + Send,
 	C::LocalContext: Send + Sync + From<L::Output>,
 	L: Sync + Send,
-	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 {
 	// If active context has a previous context, the active context is not propagated.
 	// If element does not contain an @value entry, and element does not consist of
@@ -67,7 +67,7 @@ where
 	}
 
 	// let inside_reverse = active_property == Some("@reverse");
-	let mut result = K::Object::default();
+	let mut result = <K as generic_json::Json>::Object::default();
 
 	if !node.types().is_empty() {
 		// If element has an @type entry, create a new array compacted types initialized by
@@ -219,7 +219,7 @@ where
 			}
 		}
 
-		let mut reverse_result = K::Object::default();
+		let mut reverse_result = <K as generic_json::Json>::Object::default();
 		for (expanded_property, expanded_value) in &node.reverse_properties {
 			compact_property::<J, K, _, _, _, _, _, _>(
 				&mut reverse_result,
@@ -235,7 +235,7 @@ where
 		}
 
 		// For each property and value in compacted value:
-		let mut reverse_map = K::Object::default();
+		let mut reverse_map = <K as generic_json::Json>::Object::default();
 		for (property, mut mapped_value) in reverse_result.iter_mut() {
 			let mut value = K::null(meta(None));
 			std::mem::swap(&mut value, &mut *mapped_value);
@@ -364,9 +364,9 @@ fn compact_types<
 	K: JsonFrom<J>,
 	T: Sync + Send + Id,
 	C: ContextMut<T>,
-	M: Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	M: Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 >(
-	result: &mut K::Object,
+	result: &mut <K as generic_json::Json>::Object,
 	types: &[Reference<T>],
 	active_context: Inversible<T, &C>,
 	type_scoped_context: Inversible<T, &C>,

--- a/src/compaction/property.rs
+++ b/src/compaction/property.rs
@@ -22,7 +22,7 @@ async fn compact_property_list<
 >(
 	list: &[Indexed<Object<J, T>>],
 	expanded_index: Option<&str>,
-	nest_result: &mut K::Object,
+	nest_result: &mut <K as generic_json::Json>::Object,
 	container: Container,
 	as_array: bool,
 	item_active_property: &str,
@@ -36,7 +36,7 @@ where
 	C: Sync + Send,
 	C::LocalContext: Send + Sync + From<L::Output>,
 	L: Sync + Send,
-	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 {
 	// If expanded item is a list object:
 	let mut compacted_item: K = compact_collection_with(
@@ -53,7 +53,7 @@ where
 	// If compacted item is not an array,
 	// then set `compacted_item` to an array containing only `compacted_item`.
 	if !compacted_item.is_array() {
-		let mut array = K::Array::default();
+		let mut array = <K as generic_json::Json>::Array::default();
 		array.push_back(compacted_item);
 		compacted_item = K::array(array, meta(None))
 	}
@@ -71,7 +71,7 @@ where
 			false,
 			options,
 		)?;
-		let mut compacted_item_list_object = K::Object::default();
+		let mut compacted_item_list_object = <K as generic_json::Json>::Object::default();
 		compacted_item_list_object.insert(
 			K::new_key(key.unwrap().as_str(), meta(None)),
 			compacted_item,
@@ -123,7 +123,7 @@ async fn compact_property_graph<
 >(
 	node: &Node<J, T>,
 	expanded_index: Option<&str>,
-	nest_result: &mut K::Object,
+	nest_result: &mut <K as generic_json::Json>::Object,
 	container: Container,
 	as_array: bool,
 	item_active_property: &str,
@@ -136,7 +136,7 @@ where
 	C: Sync + Send,
 	C::LocalContext: Send + Sync + From<L::Output>,
 	L: Sync + Send,
-	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 {
 	// If expanded item is a graph object
 	let mut compacted_item: K = node
@@ -161,7 +161,7 @@ where
 		if nest_result.get(item_active_property).is_none() {
 			nest_result.insert(
 				K::new_key(item_active_property, meta(None)),
-				K::object(K::Object::default(), meta(None)),
+				K::object(<K as generic_json::Json>::Object::default(), meta(None)),
 			);
 		}
 
@@ -199,7 +199,7 @@ where
 		if nest_result.get(item_active_property).is_none() {
 			nest_result.insert(
 				K::new_key(item_active_property, meta(None)),
-				K::object(K::Object::default(), meta(None)),
+				K::object(<K as generic_json::Json>::Object::default(), meta(None)),
 			);
 		}
 
@@ -234,7 +234,7 @@ where
 					options,
 				)?
 				.unwrap();
-				let mut map = K::Object::default();
+				let mut map = <K as generic_json::Json>::Object::default();
 				map.insert(
 					K::new_key(key.as_str(), meta(None)),
 					K::array(items, items_meta),
@@ -267,7 +267,7 @@ where
 			options,
 		)?
 		.unwrap();
-		let mut map = K::Object::default();
+		let mut map = <K as generic_json::Json>::Object::default();
 		map.insert(K::new_key(key.as_str(), meta(None)), compacted_item);
 
 		// If `expanded_item` contains an @id entry,
@@ -440,9 +440,9 @@ pub async fn compact_property<
 	O: IntoIterator<Item = &'a Indexed<N>>,
 	C: ContextMut<T>,
 	L: Loader,
-	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 >(
-	result: &mut K::Object,
+	result: &mut <K as generic_json::Json>::Object,
 	expanded_property: Term<T>,
 	expanded_value: O,
 	active_context: Inversible<T, &C>,
@@ -475,7 +475,7 @@ where
 		// If the term definition for `item_active_property` in the active context
 		// has a nest value entry (nest term)
 		if let Some(item_active_property) = item_active_property {
-			let (nest_result, container, as_array): (&'_ mut K::Object, _, _) =
+			let (nest_result, container, as_array): (&'_ mut <K as generic_json::Json>::Object, _, _) =
 				select_nest_result::<K, _, _, _>(
 					result,
 					active_context.clone(),

--- a/src/compaction/value.rs
+++ b/src/compaction/value.rs
@@ -27,7 +27,7 @@ where
 	C: Sync + Send,
 	C::LocalContext: Send + Sync + From<L::Output>,
 	L: Sync + Send,
-	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	M: Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 {
 	// If the term definition for active property in active context has a local context:
 	let mut active_context = active_context.into_borrowed();
@@ -59,7 +59,7 @@ where
 	// Here starts the Value Compaction Algorithm.
 
 	// Initialize result to a copy of value.
-	let mut result = K::Object::default();
+	let mut result = <K as generic_json::Json>::Object::default();
 
 	// If the active context has a null inverse context,
 	// set inverse context in active context to the result of calling the

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -300,7 +300,7 @@ impl<L: generic_json::Json, C> std::convert::AsRef<C> for ProcessedOwned<L, C> {
 impl<J: JsonClone, K: JsonFrom<J>, L: generic_json::Json + AsJson<J, K>, C> AsJson<J, K>
 	for ProcessedOwned<L, C>
 {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		self.local.as_json_with(meta)
 	}
 }
@@ -392,7 +392,7 @@ impl<'a, L: generic_json::Json, C> std::convert::AsRef<C> for Processed<'a, L, C
 impl<'a, J: JsonClone, K: JsonFrom<J>, L: generic_json::Json + AsJson<J, K>, C> AsJson<J, K>
 	for Processed<'a, L, C>
 {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		self.local.as_json_with(meta)
 	}
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -67,7 +67,7 @@ impl<J: compaction::JsonSrc, T: Sync + Send + Id> compaction::Compact<J, T>
 		C: Sync + Send,
 		C::LocalContext: Send + Sync + From<L::Output>,
 		L: Sync + Send,
-		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+		M: 'a + Send + Sync + Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 	{
 		self.objects.compact_full(
 			active_context,
@@ -101,7 +101,7 @@ impl<'a, J: JsonHash, T: Id> IntoIterator for &'a ExpandedDocument<J, T> {
 }
 
 impl<J: JsonHash + JsonClone, K: JsonFrom<J>, T: Id> AsJson<J, K> for ExpandedDocument<J, T> {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		self.objects.as_json_with(meta)
 	}
 }
@@ -236,8 +236,8 @@ pub trait Document<T: Id> {
 			+ Clone
 			+ Send
 			+ Sync
-			+ Fn(Option<&<<C::Target as Context<T>>::LocalContext as Json>::MetaData>) -> K::MetaData,
-		M2: 'a + Clone + Send + Sync + Fn(Option<&<Self::Json as Json>::MetaData>) -> K::MetaData,
+			+ Fn(Option<&<<C::Target as Context<T>>::LocalContext as Json>::MetaData>) -> <K as generic_json::Json>::MetaData,
+		M2: 'a + Clone + Send + Sync + Fn(Option<&<Self::Json as Json>::MetaData>) -> <K as generic_json::Json>::MetaData,
 		L::Output: Into<Self::Json>,
 	{
 		use compaction::Compact;
@@ -278,7 +278,7 @@ pub trait Document<T: Id> {
 
 			let (mut map, metadata) = match compacted.into_parts() {
 				(generic_json::Value::Array(items), metadata) => {
-					let mut map = K::Object::default();
+					let mut map = <K as generic_json::Json>::Object::default();
 					if !items.is_empty() {
 						use crate::syntax::{Keyword, Term};
 						let key = crate::compaction::compact_iri::<Self::Json, _, _>(

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -139,7 +139,7 @@ impl<T> AsMut<T> for Indexed<T> {
 }
 
 impl<J: JsonClone, K: JsonFrom<J>, T: AsJson<J, K>> AsJson<J, K> for Indexed<T> {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		let mut json = self.value.as_json_with(meta.clone());
 
 		if let Some(obj) = json.as_object_mut() {

--- a/src/null.rs
+++ b/src/null.rs
@@ -85,7 +85,7 @@ impl<'a, T: Clone> Nullable<&'a T> {
 
 impl<J: JsonClone, K: JsonFrom<J>, T: AsJson<J, K>> AsJson<J, K> for Nullable<T> {
 	#[inline(always)]
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		match self {
 			Nullable::Null => K::null(meta(None)),
 			Nullable::Some(t) => t.as_json_with(meta),

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -313,12 +313,12 @@ impl<J: JsonHash, T: Id> From<Node<J, T>> for Object<J, T> {
 }
 
 impl<J: JsonHash + JsonClone, K: JsonFrom<J>, T: Id> AsJson<J, K> for Object<J, T> {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		match self {
 			Object::Value(v) => v.as_json_with(meta),
 			Object::Node(n) => n.as_json_with(meta),
 			Object::List(items) => {
-				let mut obj = K::Object::default();
+				let mut obj = <K as generic_json::Json>::Object::default();
 				obj.insert(
 					K::new_key(Keyword::List.into_str(), meta(None)),
 					items.as_json_with(meta.clone()),
@@ -333,7 +333,7 @@ impl<J: JsonHash + JsonClone, K: JsonFrom<J>, T: Id> AsJson<J, K>
 	for HashSet<Indexed<Object<J, T>>>
 {
 	#[inline(always)]
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		let array = self
 			.iter()
 			.map(|value| value.as_json_with(meta.clone()))

--- a/src/object/node.rs
+++ b/src/object/node.rs
@@ -370,8 +370,8 @@ impl<J: JsonHash, T: Id> Hash for Node<J, T> {
 }
 
 impl<J: JsonHash + JsonClone, K: util::JsonFrom<J>, T: Id> util::AsJson<J, K> for Node<J, T> {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
-		let mut obj = K::Object::default();
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
+		let mut obj = <K as generic_json::Json>::Object::default();
 
 		if let Some(id) = &self.id {
 			obj.insert(
@@ -402,7 +402,7 @@ impl<J: JsonHash + JsonClone, K: util::JsonFrom<J>, T: Id> util::AsJson<J, K> fo
 		}
 
 		if !self.reverse_properties.is_empty() {
-			let mut reverse = K::Object::default();
+			let mut reverse = <K as generic_json::Json>::Object::default();
 			for (key, value) in &self.reverse_properties {
 				reverse.insert(
 					K::new_key(key.as_str(), meta(None)),
@@ -431,7 +431,7 @@ impl<J: JsonHash + JsonClone, K: util::JsonFrom<J>, T: Id> util::AsJson<J, K>
 	for HashSet<Indexed<Node<J, T>>>
 {
 	#[inline(always)]
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		let array = self
 			.iter()
 			.map(|value| value.as_json_with(meta.clone()))

--- a/src/object/value.rs
+++ b/src/object/value.rs
@@ -262,8 +262,8 @@ impl<J: JsonHash, T: Id> Hash for Value<J, T> {
 }
 
 impl<J: JsonClone, K: util::JsonFrom<J>, T: Id> util::AsJson<J, K> for Value<J, T> {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
-		let mut obj = K::Object::default();
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
+		let mut obj = <K as generic_json::Json>::Object::default();
 
 		match self {
 			Value::Literal(lit, ty) => {

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -157,7 +157,7 @@ impl<T: AsIri> From<BlankId> for Reference<T> {
 
 impl<J: JsonClone, K: util::JsonFrom<J>, T: Id> util::AsJson<J, K> for Reference<T> {
 	#[inline]
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		match self {
 			Reference::Id(id) => id.as_json(meta(None)),
 			Reference::Blank(b) => b.as_json_with(meta(None)),

--- a/src/util/json/build.rs
+++ b/src/util/json/build.rs
@@ -45,9 +45,9 @@ pub trait AsAnyJson<K: JsonBuild> {
 /// Converts a JSON value into the same JSON value represented with another type.
 fn json_to_json<J: JsonClone, K: JsonFrom<J>>(
 	input: &J,
-	m: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData,
+	m: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData,
 ) -> K {
-	let meta: K::MetaData = m(Some(input.metadata()));
+	let meta: <K as generic_json::Json>::MetaData = m(Some(input.metadata()));
 	match input.as_value_ref() {
 		ValueRef::Null => K::null(meta),
 		ValueRef::Boolean(b) => K::boolean(b, meta),
@@ -74,7 +74,7 @@ fn json_to_json<J: JsonClone, K: JsonFrom<J>>(
 }
 
 impl<J: JsonClone, K: JsonFrom<J>> AsJson<J, K> for J {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
 		json_to_json(self, meta)
 	}
 }
@@ -116,8 +116,8 @@ impl<K: JsonBuild, T: AsRef<[u8]>> AsAnyJson<K> for LanguageTagBuf<T> {
 }
 
 impl<J: JsonClone, K: JsonFrom<J>, T: AsJson<J, K>> AsJson<J, K> for [T] {
-	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
-		let array = K::Array::from_iter(self.iter().map(|value| value.as_json_with(meta.clone())));
+	fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> <K as generic_json::Json>::MetaData) -> K {
+		let array = <K as generic_json::Json>::Array::from_iter(self.iter().map(|value| value.as_json_with(meta.clone())));
 		Value::<K>::Array(array).with(meta(None))
 	}
 }


### PR DESCRIPTION
Resolves #40 

Thanks to @ashbeitz for the suggested fix.

This is noisy, but necessary to resolve the following error:

```
error[E0221]: ambiguous associated type `MetaData` in bounds of `K`
   --> src/indexed.rs:142:72
    |
142 |     fn as_json_with(&self, meta: impl Clone + Fn(Option<&J::MetaData>) -> K::MetaData) -> K {
    |                                                                           ^^^^^^^^^^^ ambiguous associated type `MetaData`
    |
    = note: associated type `K` could derive from `generic_json::Json`
    = note: associated type `K` could derive from `generic_json::Json`
```

If this is a bug in the compiler, undoing this is simply applying `s/<K as generic_json::Json>/K/g` and possibly undoing a handful of intentional casts that get caught in the blast. If this is a bug in json-ld, this PR can be ignored and the bug can be resolved another way.

Thank you