### PR TITLE
Add RDF deserialization to the processor API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,14 @@ jobs:
           override: true
       - name: Build
         run: cargo build --verbose
-      - name: Run tests
+      - name: Init tests
         run: |
           git submodule init
           git submodule update
-          cargo test --verbose
+      - name: Library tests
+        run: cargo test --verbose --lib
+      - name: Doc tests
+        run: cargo test --verbose -j1 --doc
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0]
+### Changed
+- Use `rdf_types::Literal` instead of `json_ld::rdf::Value`.
+
+### Added
+- `JsonLdProcessor::to_rdf*` functions for RDF serialization.
+- `toRdf` test suite.
+
 ## [0.9.1]
 ### Changed
 - All the library has been refactored. Please take a look at the `README.md`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 authors = ["Timothée Haudebourg <timothee@haudebourg.net>"]
 categories = ["web-programming", "database", "data-structures"]
@@ -21,13 +21,13 @@ repository = "https://github.com/timothee-haudebourg/json-ld"
 license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
-json-ld = { path = "json-ld", version = "0.9.1" }
-json-ld-syntax = { path = "syntax", version = "0.9.1" }
-json-ld-core = { path = "core", version = "0.9.1" }
-json-ld-context-processing = { path = "context-processing", version = "0.9.1" }
-json-ld-expansion = { path = "expansion", version = "0.9.1" }
-json-ld-compaction = { path = "compaction", version = "0.9.1" }
-json-ld-testing = { path = "testing", version = "0.9.1" }
+json-ld = { path = "json-ld", version = "0.10.0" }
+json-ld-syntax = { path = "syntax", version = "0.10.0" }
+json-ld-core = { path = "core", version = "0.10.0" }
+json-ld-context-processing = { path = "context-processing", version = "0.10.0" }
+json-ld-expansion = { path = "expansion", version = "0.10.0" }
+json-ld-compaction = { path = "compaction", version = "0.10.0" }
+json-ld-testing = { path = "testing", version = "0.10.0" }
 json-syntax = "0.8.17"
 iref = "2.2"
 static-iref = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
-	"core",
 	"syntax",
+	"core",
 	"context-processing",
 	"expansion",
 	"compaction",
@@ -10,3 +10,39 @@ members = [
 	"json-ld",
 	"cli"
 ]
+
+[workspace.package]
+version = "0.9.1"
+edition = "2021"
+authors = ["Timothée Haudebourg <timothee@haudebourg.net>"]
+categories = ["web-programming", "database", "data-structures"]
+keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
+repository = "https://github.com/timothee-haudebourg/json-ld"
+license = "MIT/Apache-2.0"
+
+[workspace.dependencies]
+json-ld = { path = "json-ld", version = "0.9.1" }
+json-ld-syntax = { path = "syntax", version = "0.9.1" }
+json-ld-core = { path = "core", version = "0.9.1" }
+json-ld-context-processing = { path = "context-processing", version = "0.9.1" }
+json-ld-expansion = { path = "expansion", version = "0.9.1" }
+json-ld-compaction = { path = "compaction", version = "0.9.1" }
+json-ld-testing = { path = "testing", version = "0.9.1" }
+json-syntax = "0.8.17"
+iref = "2.2"
+static-iref = "2"
+langtag = "0.3"
+rdf-types = "0.12.9"
+contextual = "0.1.4"
+locspan = "0.7.12"
+locspan-derive = "0.6"
+derivative = "2.2"
+futures = "0.3"
+mown = "0.2.2"
+hashbrown = "0.13.1"
+smallvec = "1.10"
+log = "0.4.17"
+
+iref-enum = "2.1"
+grdf = "0.14"
+async-std = "1.12"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,24 +1,23 @@
 [package]
 name = "json-ld-cli"
-version = "0.9.1"
-edition = "2021"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "Command line interface for JSON-LD"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
-repository = "https://github.com/timothee-haudebourg/json-ld"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-json-ld = { path = "../json-ld", version = "0.9.1", features = ["reqwest"] }
-json-ld-testing = { path = "../testing", version = "0.9.1" }
-iref = "2.2"
-static-iref = "2.0"
-rdf-types = "0.12.3"
-locspan = "0.7.9"
+json-ld = { workspace = true, features = ["reqwest"] }
+iref.workspace = true
+static-iref.workspace = true
+rdf-types.workspace = true
+contextual.workspace = true
+locspan.workspace = true
+log.workspace = true
 tokio = { version = "1.23", features = ["rt-multi-thread", "net", "macros"] }
-log = "0.4.17"
 stderrlog = "0.5"
-contextual = "0.1.3"
 clap = { version = "3.0", features = ["derive"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
 use clap::Parser;
 use contextual::WithContext;
 use iref::IriBuf;
@@ -23,20 +26,60 @@ pub enum Command {
 
 	/// Expand the given JSON-LD document.
 	Expand {
-		/// URL of the document to expand.
+		/// URL or file path of the document to expand.
 		///
 		/// Of none, the standard input is used.
-		url: Option<IriBuf>,
+		url_or_path: Option<IriOrPath>,
 
-		/// Base URL to use when reading from the standard input.
+		/// Base URL to use when reading from the standard input or file system.
+		#[clap(short, long)]
+		base_url: Option<IriBuf>,
+
+		/// Relabel the nodes.
+		///
+		/// This will give a blank node identifier to unidentified nodes and
+		/// replace existing blank node identifiers.
+		#[clap(short = 'l', long)]
+		relabel: bool,
+
+		/// Put the expanded document in canonical form.
+		#[clap(short, long)]
+		canonicalize: bool,
+	},
+
+	Flatten {
+		/// URL or file path of the document to flatten.
+		///
+		/// Of none, the standard input is used.
+		url_or_path: Option<IriOrPath>,
+
+		/// Base URL to use when reading from the standard input or file system.
 		#[clap(short, long)]
 		base_url: Option<IriBuf>,
 	},
 }
 
+pub enum IriOrPath {
+	Iri(IriBuf),
+	Path(PathBuf),
+}
+
+impl FromStr for IriOrPath {
+	type Err = std::convert::Infallible;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match IriBuf::new(s) {
+			Ok(iri) => Ok(Self::Iri(iri)),
+			Err(_) => Ok(Self::Path(s.into())),
+		}
+	}
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Source {
+	Nowhere,
 	StdIn,
+	Path,
 	Iri(rdf_types::vocabulary::Index),
 }
 
@@ -75,48 +118,121 @@ async fn main() {
 				}
 			}
 		}
-		Command::Expand { url, base_url } => {
-			let remote_document = match url {
-				Some(url) => {
-					let url = vocabulary.insert(url.as_iri());
-					RemoteDocumentReference::iri(url)
-				}
-				None => {
-					let url = base_url.map(|iri| vocabulary.insert(iri.as_iri()));
-					let source = url.map(Source::Iri).unwrap_or(Source::StdIn);
+		Command::Expand {
+			url_or_path,
+			base_url,
+			relabel,
+			canonicalize,
+		} => {
+			let remote_document = get_remote_document(&mut vocabulary, url_or_path, base_url);
 
-					match std::io::read_to_string(std::io::stdin()) {
-						Ok(content) => {
-							match json_ld::syntax::Value::parse_str(&content, |span| {
-								Location::new(source, span)
-							}) {
-								Ok(document) => {
-									RemoteDocumentReference::Loaded(RemoteDocument::new(
-										url,
-										Some("application/ld+json".parse().unwrap()),
-										document,
-									))
-								}
-								Err(e) => {
-									eprintln!("error: {}", e);
-									std::process::exit(1);
-								}
-							}
+			match remote_document
+				.expand_with(&mut vocabulary, &mut loader)
+				.await
+			{
+				Ok(mut expanded) => {
+					if relabel {
+						let mut generator =
+							rdf_types::generator::Blank::new_with_prefix("b".to_string())
+								.with_metadata(*expanded.metadata());
+
+						if canonicalize {
+							expanded.relabel_and_canonicalize_with(&mut vocabulary, &mut generator)
+						} else {
+							expanded.relabel_with(&mut vocabulary, &mut generator)
 						}
+					} else if canonicalize {
+						expanded.canonicalize()
+					}
+
+					println!("{}", expanded.with(&vocabulary).pretty_print())
+				}
+				Err(e) => {
+					eprintln!("error: {}", e);
+					std::process::exit(1);
+				}
+			}
+		}
+		Command::Flatten {
+			url_or_path,
+			base_url,
+		} => {
+			let remote_document = get_remote_document(&mut vocabulary, url_or_path, base_url);
+
+			let mut generator = rdf_types::generator::Blank::new_with_prefix("b".to_string())
+				.with_metadata(Location::new(Source::Nowhere, Span::default()));
+
+			match remote_document
+				.flatten_with(&mut vocabulary, &mut generator, &mut loader)
+				.await
+			{
+				Ok(flattened) => {
+					println!("{}", flattened.with(&vocabulary).pretty_print())
+				}
+				Err(e) => {
+					eprintln!("error: {}", e);
+					std::process::exit(1);
+				}
+			}
+		}
+	}
+}
+
+fn get_remote_document(
+	vocabulary: &mut impl IriVocabularyMut<Iri = Index>,
+	url_or_path: Option<IriOrPath>,
+	base_url: Option<IriBuf>,
+) -> RemoteDocumentReference<Index, Location<Source, Span>> {
+	match url_or_path {
+		Some(IriOrPath::Iri(url)) => {
+			let url = vocabulary.insert(url.as_iri());
+			RemoteDocumentReference::iri(url)
+		}
+		Some(IriOrPath::Path(path)) => {
+			let url = base_url.map(|iri| vocabulary.insert(iri.as_iri()));
+			let source = url.map(Source::Iri).unwrap_or(Source::Path);
+
+			match std::fs::read_to_string(path) {
+				Ok(content) => {
+					match json_ld::syntax::Value::parse_str(&content, |span| {
+						Location::new(source, span)
+					}) {
+						Ok(document) => RemoteDocumentReference::Loaded(RemoteDocument::new(
+							url,
+							Some("application/ld+json".parse().unwrap()),
+							document,
+						)),
 						Err(e) => {
 							eprintln!("error: {}", e);
 							std::process::exit(1);
 						}
 					}
 				}
-			};
+				Err(e) => {
+					eprintln!("error: {}", e);
+					std::process::exit(1);
+				}
+			}
+		}
+		None => {
+			let url = base_url.map(|iri| vocabulary.insert(iri.as_iri()));
+			let source = url.map(Source::Iri).unwrap_or(Source::StdIn);
 
-			match remote_document
-				.expand_with(&mut vocabulary, &mut loader)
-				.await
-			{
-				Ok(expanded) => {
-					println!("{}", expanded.with(&vocabulary).pretty_print())
+			match std::io::read_to_string(std::io::stdin()) {
+				Ok(content) => {
+					match json_ld::syntax::Value::parse_str(&content, |span| {
+						Location::new(source, span)
+					}) {
+						Ok(document) => RemoteDocumentReference::Loaded(RemoteDocument::new(
+							url,
+							Some("application/ld+json".parse().unwrap()),
+							document,
+						)),
+						Err(e) => {
+							eprintln!("error: {}", e);
+							std::process::exit(1);
+						}
+					}
 				}
 				Err(e) => {
 					eprintln!("error: {}", e);

--- a/compaction/Cargo.toml
+++ b/compaction/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "json-ld-compaction"
-version = "0.9.1"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
-edition = "2021"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "A JSON-LD document compaction implementation"
-repository = "https://github.com/timothee-haudebourg/json-ld"
 documentation = "https://docs.rs/json-ld-compaction"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-json-ld-core = { path = "../core", version = "0.9.1" }
-json-ld-syntax = { path = "../syntax", version = "0.9.1" }
-json-ld-context-processing = { path = "../context-processing", version = "0.9.1" }
-json-ld-expansion = { path = "../expansion", version = "0.9.1" }
-json-syntax = "0.8.14"
-langtag = "0.3"
-iref = "2.2"
-contextual = "0.1.3"
-rdf-types = "0.12.3"
-futures = "^0.3"
-mown = "0.2.1"
-locspan = "0.7.9"
-derivative = "2.2"
+json-ld-core.workspace = true
+json-ld-syntax.workspace = true
+json-ld-context-processing.workspace = true
+json-ld-expansion.workspace = true
+json-syntax.workspace = true
+langtag.workspace = true
+iref.workspace = true
+contextual.workspace = true
+rdf-types.workspace = true
+futures.workspace = true
+mown.workspace = true
+locspan.workspace = true
+derivative.workspace = true

--- a/context-processing/Cargo.toml
+++ b/context-processing/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "json-ld-context-processing"
-version = "0.9.1"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
-edition = "2021"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "A JSON-LD context processing implementation"
-repository = "https://github.com/timothee-haudebourg/json-ld"
 documentation = "https://docs.rs/json-ld-context-processing"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-json-ld-core = { path = "../core", version = "0.9.1" }
-json-ld-syntax = { path = "../syntax", version = "0.9.1" }
-iref = "2.2"
-rdf-types = "0.12.3"
-futures = "^0.3"
-mown = "0.2.1"
-locspan = "0.7.9"
-contextual = "0.1.3"
+json-ld-core.workspace = true
+json-ld-syntax.workspace = true
+iref.workspace = true
+rdf-types.workspace = true
+futures.workspace = true
+mown.workspace = true
+locspan.workspace = true
+contextual.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "json-ld-core"
-version = "0.9.1"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
-edition = "2021"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "A JSON-LD implementation"
-repository = "https://github.com/timothee-haudebourg/json-ld"
 documentation = "https://docs.rs/json-ld"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [features]
@@ -16,27 +16,28 @@ default = []
 reqwest = ["bytes", "dep:reqwest"]
 
 [dependencies]
-json-ld-syntax = { path = "../syntax", version = "0.9.1" }
-json-syntax = { version = "0.8.14", features = ["contextual"] }
-log = "^0.4"
-derivative = "^2.2"
-mown = "^0.2"
-iref = "2.2"
-static-iref = "2.0"
-futures = "^0.3"
+json-ld-syntax.workspace = true
+json-syntax = { workspace = true, features = ["contextual", "canonicalize"] }
+rdf-types = { workspace = true, features = ["contextual", "meta"] }
+locspan = { workspace = true, features = ["hashbrown"] }
+locspan-derive.workspace = true
+contextual.workspace = true
+log.workspace = true
+derivative.workspace = true
+mown.workspace = true
+iref.workspace = true
+static-iref.workspace = true
+futures.workspace = true
+langtag.workspace = true
+smallvec.workspace = true
+hashbrown.workspace = true
 once_cell = "^1.4"
-langtag = "0.3"
-smallvec = "1.10.0"
+ryu-js = "0.2.2"
 permutohedron = { version = "0.2" }
 pretty_dtoa = "0.3"
-rdf-types = { version = "0.12.4", features = ["contextual", "meta"] }
-locspan = { version = "0.7.12", features = ["hashbrown"] }
-locspan-derive = "0.6"
-contextual = "0.1.3"
-hashbrown = "0.13.1"
 mime = "0.3"
 reqwest = { version = "^0.11", optional = true }
 bytes = { version = "^1.3", optional = true }
 
 [dev-dependencies]
-iref-enum = "2.1"
+iref-enum.workspace = true

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -164,13 +164,15 @@ pub struct RemoteDocument<I = Index, M = Location<I>, T = json_syntax::Value<M>>
 	/// of any optional parameters.
 	content_type: Option<Mime>,
 
-	/// If available, the value of the HTTP `Link Header` [RFC8288] using the
+	/// If available, the value of the HTTP `Link Header` [RFC 8288] using the
 	/// `http://www.w3.org/ns/json-ld#context` link relation in the response.
 	///
 	/// If the response's `Content-Type` is `application/ld+json`, the HTTP
 	/// `Link Header` is ignored. If multiple HTTP `Link Headers` using the
 	/// `http://www.w3.org/ns/json-ld#context` link relation are found, the
 	/// loader fails with a `multiple context link headers` error.
+	///
+	/// [RFC 8288]: https://www.rfc-editor.org/rfc/rfc8288
 	context_url: Option<I>,
 
 	profile: HashSet<Profile<I>>,
@@ -196,11 +198,13 @@ impl<I, M, T> RemoteDocument<I, M, T> {
 	/// redirection.
 	/// `content_type` is the HTTP `Content-Type` header value of the loaded
 	/// document, exclusive of any optional parameters.
-	/// `context_url` is the value of the HTTP `Link Header` [RFC8288] using the
+	/// `context_url` is the value of the HTTP `Link Header` [RFC 8288] using the
 	/// `http://www.w3.org/ns/json-ld#context` link relation in the response,
 	/// if any.
 	/// `profile` is the value of any profile parameter retrieved as part of the
 	/// original contentType.
+	///
+	/// [RFC 8288]: https://www.rfc-editor.org/rfc/rfc8288
 	pub fn new_full(
 		url: Option<I>,
 		content_type: Option<Mime>,
@@ -253,7 +257,7 @@ impl<I, M, T> RemoteDocument<I, M, T> {
 		self.content_type.as_ref()
 	}
 
-	/// Returns the value of the HTTP `Link Header` [RFC8288] using the
+	/// Returns the value of the HTTP `Link Header` [RFC 8288] using the
 	/// `http://www.w3.org/ns/json-ld#context` link relation in the response,
 	/// if any.
 	///
@@ -261,6 +265,8 @@ impl<I, M, T> RemoteDocument<I, M, T> {
 	/// `Link Header` is ignored. If multiple HTTP `Link Headers` using the
 	/// `http://www.w3.org/ns/json-ld#context` link relation are found, the
 	/// loader fails with a `multiple context link headers` error.
+	///
+	/// [RFC 8288]: https://www.rfc-editor.org/rfc/rfc8288
 	pub fn context_url(&self) -> Option<&I> {
 		self.context_url.as_ref()
 	}

--- a/core/src/object/value.rs
+++ b/core/src/object/value.rs
@@ -190,6 +190,21 @@ impl Literal {
 			Self::String(LiteralString::Inferred(s)) => json_syntax::Value::String(s.into()),
 		}
 	}
+
+	/// Puts this literal into canonical form using the given `buffer`.
+	///
+	/// The buffer is used to compute the canonical form of numbers.
+	pub fn canonicalize_with(&mut self, buffer: &mut ryu_js::Buffer) {
+		if let Self::Number(n) = self {
+			*n = NumberBuf::from_number(n.canonical_with(buffer))
+		}
+	}
+
+	/// Puts this literal into canonical form.
+	pub fn canonicalize(&mut self) {
+		let mut buffer = ryu_js::Buffer::new();
+		self.canonicalize_with(&mut buffer)
+	}
 }
 
 /// Value object.
@@ -389,6 +404,24 @@ impl<T, M> Value<T, M> {
 				}
 			}
 		}
+	}
+
+	/// Puts this value object literal into canonical form using the given
+	/// `buffer`.
+	///
+	/// The buffer is used to compute the canonical form of numbers.
+	pub fn canonicalize_with(&mut self, buffer: &mut ryu_js::Buffer) {
+		match self {
+			Self::Json(json) => json.canonicalize_with(buffer),
+			Self::Literal(l, _) => l.canonicalize_with(buffer),
+			Self::LangString(_) => (),
+		}
+	}
+
+	/// Puts this literal into canonical form.
+	pub fn canonicalize(&mut self) {
+		let mut buffer = ryu_js::Buffer::new();
+		self.canonicalize_with(&mut buffer)
 	}
 }
 

--- a/expansion/Cargo.toml
+++ b/expansion/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
 name = "json-ld-expansion"
-version = "0.9.1"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
-edition = "2021"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "A JSON-LD document expansion implementation"
-repository = "https://github.com/timothee-haudebourg/json-ld"
 documentation = "https://docs.rs/json-ld-context-processing"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-json-ld-core = { path = "../core", version = "0.9.1" }
-json-ld-syntax = { path = "../syntax", version = "0.9.1" }
-json-ld-context-processing = { path = "../context-processing", version = "0.9.1" }
-json-syntax = "0.8.14"
-langtag = "0.3"
-iref = "2.2"
-rdf-types = "0.12.3"
-futures = "^0.3"
-mown = "0.2.1"
-locspan = { version = "0.7.9", features = ["contextual"] }
-derivative = "2.2"
-contextual = "0.1.3"
+json-ld-core.workspace = true
+json-ld-syntax.workspace = true
+json-ld-context-processing.workspace = true
+json-syntax.workspace = true
+langtag.workspace = true
+iref.workspace = true
+rdf-types.workspace = true
+futures.workspace = true
+mown.workspace = true
+locspan = { workspace = true, features = ["contextual"] }
+derivative.workspace = true
+contextual.workspace = true
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
-static-iref = "2.0"
+async-std = { workspace = true, features = ["attributes"] }
+static-iref.workspace = true

--- a/json-ld/Cargo.toml
+++ b/json-ld/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
 name = "json-ld"
-version = "0.9.1"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
-edition = "2018"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "A JSON-LD implementation"
-repository = "https://github.com/timothee-haudebourg/json-ld"
 documentation = "https://docs.rs/json-ld"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [features]
 reqwest = ["json-ld-core/reqwest"]
 
 [dependencies]
-json-ld-syntax = { path = "../syntax", version = "0.9.1" }
-json-ld-core = { path = "../core", version = "0.9.1" }
-json-ld-context-processing = { path = "../context-processing", version = "0.9.1" }
-json-ld-expansion = { path = "../expansion", version = "0.9.1" }
-json-ld-compaction = { path = "../compaction", version = "0.9.1" }
-json-syntax = "0.8.14"
-futures = "^0.3"
-locspan = "0.7.9"
-rdf-types = "0.12.3"
-contextual = "0.1.3"
+json-ld-syntax.workspace = true
+json-ld-core.workspace = true
+json-ld-context-processing.workspace = true
+json-ld-expansion.workspace = true
+json-ld-compaction.workspace = true
+json-syntax.workspace = true
+futures.workspace = true
+locspan.workspace = true
+rdf-types.workspace = true
+contextual.workspace = true
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
-iref = "2.2"
-static-iref = "2.0"
+async-std = { workspace = true, features = ["attributes"] }
+iref.workspace = true
+static-iref.workspace = true

--- a/syntax/Cargo.toml
+++ b/syntax/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "json-ld-syntax"
-version = "0.9.1"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
-edition = "2021"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "A JSON-LD context processing implementation"
-repository = "https://github.com/timothee-haudebourg/json-ld"
 documentation = "https://docs.rs/json-ld-context-processing"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-iref = "2.2"
-langtag = "0.3.2"
-rdf-types = "0.12.3"
-json-syntax = "0.8.14"
-locspan = "0.7.9"
-locspan-derive = "0.6"
-hashbrown = "0.12.1"
-derivative = "2.2.0"
+iref.workspace = true
+langtag.workspace = true
+rdf-types.workspace = true
+json-syntax.workspace = true
+locspan.workspace = true
+locspan-derive.workspace = true
+hashbrown.workspace = true
+derivative.workspace = true
+smallvec.workspace = true
+contextual.workspace = true
 indexmap = "1.9.1" # TODO remove indexmap
-smallvec = "1.9"
 decoded-char = "0.1.0"
-contextual = "0.1.3"

--- a/syntax/src/into_json.rs
+++ b/syntax/src/into_json.rs
@@ -118,48 +118,6 @@ impl<M> IntoJsonMeta<M> for String {
 	}
 }
 
-// impl<M> IntoJsonMeta<M> for Value<M> {
-// 	fn into_json_meta(self, meta: M) -> Meta<json_syntax::Value<M>, M> {
-// 		let json = match value {
-// 			Self::Null => json_syntax::Value::Null,
-// 			Self::Boolean(b) => json_syntax::Value::Boolean(b),
-// 			Self::Number(n) => json_syntax::Value::Number(n),
-// 			Self::String(s) => json_syntax::Value::String(s),
-// 			Self::Array(a) => {
-// 				json_syntax::Value::Array(a.into_iter().map(Self::into_json).collect())
-// 			}
-// 			Self::Object(o) => json_syntax::Value::Object(o.into_json_object()),
-// 		};
-
-// 		Meta(json, meta)
-// 	}
-// }
-
-// impl<M> Object<M> {
-// 	pub fn into_json_object(self) -> json_syntax::Object<M> {
-// 		let mut result = Vec::new();
-
-// 		result.extend(self.into_iter().map(object::Entry::into_json));
-
-// 		json_syntax::Object::from_vec(result)
-// 	}
-// }
-
-// impl<M> IntoJsonMeta<M> for Object<M> {
-// 	fn into_json(Meta(object, meta): Meta<Self, M>) -> Meta<json_syntax::Value<M>, M> {
-// 		Meta(json_syntax::Value::Object(object.into_json_object()), meta)
-// 	}
-// }
-
-// impl<M> object::Entry<M> {
-// 	pub fn into_json(self) -> json_syntax::object::Entry<M> {
-// 		json_syntax::object::Entry {
-// 			key: self.key,
-// 			value: Value::into_json(self.value),
-// 		}
-// 	}
-// }
-
 impl<T, M> Entry<T, M> {
 	pub fn insert_in_json_object(
 		self,

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "json-ld-testing"
-version = "0.9.1"
-edition = "2021"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "Testing library for the `json-ld` library"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
-repository = "https://github.com/timothee-haudebourg/json-ld"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [lib]
@@ -15,18 +15,18 @@ proc-macro = true
 path = "src/lib.rs"
 
 [dependencies]
-json-ld = { path = "../json-ld", version = "0.9.1" }
+json-ld.workspace = true
+iref.workspace = true
+static-iref.workspace = true
+iref-enum.workspace = true
+rdf-types.workspace = true
+grdf = { workspace = true, features = ["meta"] }
+locspan.workspace = true
+contextual.workspace = true
+async-std.workspace = true
 syn = { version = "1.0", features = ["full"] }
 litrs = "0.2.3"
 quote = "1.0"
 proc-macro2 = "1.0"
 proc-macro-error = "1.0"
-iref = "2.2"
-static-iref = "2.0"
-iref-enum = "2.1.0"
-rdf-types = "0.12.3"
-grdf = { version = "0.14", features = ["meta"] }
-locspan = "0.7.9"
-contextual = "0.1.3"
-async-std = "1.12.0"
 yansi = "0.5.1"

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -563,7 +563,7 @@ async fn generate_test_suite(
 	for Triple(subject, predicate, object) in dataset.default_graph() {
 		if let ValidId::Iri(id) = subject {
 			if *predicate == ValidId::Iri(IriIndex::Iri(Vocab::Rdf(vocab::Rdf::Type))) {
-				if let json_ld::rdf::Value::Reference(ValidId::Iri(ty)) = object {
+				if let json_ld::rdf::Value::Iri(ty) = object {
 					if let Some(type_id) = spec.type_map.get(ty) {
 						match spec.ignore.get(id) {
 							Some(link) => {

--- a/testing/src/ty/parse.rs
+++ b/testing/src/ty/parse.rs
@@ -99,6 +99,8 @@ fn parse_path(p: syn::TypePath) -> Result<Type, UnknownType> {
 		Ok(Type::Iri)
 	} else if is_processing_mode_path(&p) {
 		Ok(Type::ProcessingMode)
+	} else if is_rdf_direction_path(&p) {
+		Ok(Type::RdfDirection)
 	} else if p.path.leading_colon.is_none()
 		&& p.path.segments.len() == 1
 		&& p.path.segments[0].arguments.is_empty()
@@ -184,6 +186,16 @@ fn is_processing_mode_path(p: &syn::TypePath) -> bool {
 			|| (p.path.leading_colon.is_none()
 				&& p.path.segments.len() == 1
 				&& segment_is_empty_ident(&p.path, 0, "ProcessingMode")))
+}
+
+fn is_rdf_direction_path(p: &syn::TypePath) -> bool {
+	p.qself.is_none()
+		&& ((p.path.segments.len() == 2
+			&& segment_is_empty_ident(&p.path, 0, "json_ld")
+			&& segment_is_empty_ident(&p.path, 1, "RdfDirection"))
+			|| (p.path.leading_colon.is_none()
+				&& p.path.segments.len() == 1
+				&& segment_is_empty_ident(&p.path, 0, "RdfDirection")))
 }
 
 fn is_option_path(p: &syn::TypePath) -> bool {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,25 +1,26 @@
 [package]
 name = "json-ld-tests"
-version = "0.9.1"
-edition = "2021"
-authors = ["Timothée Haudebourg <author@haudebourg.net>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license.workspace = true
 description = "Testing library for the `json-ld` library"
-categories = ["web-programming", "database", "data-structures"]
-keywords = ["json-ld", "json", "semantic-web", "linked-data", "rdf"]
-repository = "https://github.com/timothee-haudebourg/json-ld"
-license = "MIT/Apache-2.0"
 readme = "README.md"
 exclude = [ "/json-ld-api" ]
 
 [dependencies]
-json-ld = { path = "../json-ld", version = "0.9.1" }
-json-ld-testing = { path = "../testing", version = "0.9.1" }
-iref = "2.2"
-static-iref = "2.0"
-iref-enum = "2.1.0"
-rdf-types = "0.12.3"
-locspan = "0.7.9"
-async-std = { version = "1.12", features = ["attributes"] }
-log = "0.4.17"
-grdf = { version = "0.14", features = ["meta"] }
-contextual = "0.1.3"
+json-ld.workspace = true
+json-ld-testing.workspace = true
+iref.workspace = true
+static-iref.workspace = true
+iref-enum.workspace = true
+rdf-types.workspace = true
+locspan.workspace = true
+async-std = { workspace = true, features = ["attributes"] }
+log.workspace = true
+grdf = { workspace = true, features = ["meta"] }
+contextual.workspace = true
+nquads-syntax = "0.10.0"

--- a/tests/tests/to_rdf.rs
+++ b/tests/tests/to_rdf.rs
@@ -1,0 +1,209 @@
+use contextual::WithContext;
+use json_ld::{JsonLdProcessor, Loader, Print, RemoteDocumentReference};
+use locspan::{Meta, Strip};
+use nquads_syntax::Parse;
+use rdf_types::{IndexVocabulary, IriVocabularyMut};
+use static_iref::iri;
+
+const STACK_SIZE: usize = 4 * 1024 * 1024;
+
+#[json_ld_testing::test_suite("https://w3c.github.io/json-ld-api/tests/toRdf-manifest.jsonld")]
+#[mount("https://w3c.github.io/json-ld-api", "tests/json-ld-api")]
+#[iri_prefix("rdf" = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")]
+#[iri_prefix("rdfs" = "http://www.w3.org/2000/01/rdf-schema#")]
+#[iri_prefix("manifest" = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#")]
+#[iri_prefix("jld" = "https://w3c.github.io/json-ld-api/tests/vocab#")]
+#[ignore_test("#te122", see = "https://github.com/w3c/json-ld-api/issues/480")]
+#[ignore_test("#tli12", see = "https://github.com/w3c/json-ld-api/issues/533")]
+mod to_rdf {
+	use iref::Iri;
+	use json_ld::rdf::RdfDirection;
+
+	#[iri("jld:ToRDFTest")]
+	pub struct Test {
+		#[iri("rdfs:comment")]
+		pub comments: &'static [&'static str],
+
+		#[iri("manifest:action")]
+		pub input: Iri<'static>,
+
+		#[iri("manifest:name")]
+		pub name: &'static str,
+
+		#[iri("jld:option")]
+		pub options: Options,
+
+		#[iri("rdf:type")]
+		pub desc: Description,
+	}
+
+	pub enum Description {
+		#[iri("jld:PositiveEvaluationTest")]
+		Positive {
+			#[iri("manifest:result")]
+			expect: Iri<'static>,
+		},
+		#[iri("jld:NegativeEvaluationTest")]
+		Negative {
+			#[iri("manifest:result")]
+			expected_error_code: &'static str,
+		},
+		#[iri("jld:PositiveSyntaxTest")]
+		PositiveSyntax {
+			// ...
+		},
+	}
+
+	#[derive(Default)]
+	pub struct Options {
+		#[iri("jld:base")]
+		pub base: Option<Iri<'static>>,
+
+		#[iri("jld:processingMode")]
+		pub processing_mode: Option<json_ld::ProcessingMode>,
+
+		#[iri("jld:specVersion")]
+		pub spec_version: Option<&'static str>,
+
+		#[iri("jld:normative")]
+		pub normative: Option<bool>,
+
+		#[iri("jld:expandContext")]
+		pub expand_context: Option<Iri<'static>>,
+
+		#[iri("jld:produceGeneralizedRdf")]
+		pub produce_generalized_rdf: bool,
+
+		#[iri("jld:rdfDirection")]
+		pub rdf_direction: Option<RdfDirection>,
+	}
+}
+
+impl to_rdf::Test {
+	fn run(self) {
+		let child = std::thread::Builder::new()
+			.stack_size(STACK_SIZE)
+			.spawn(|| async_std::task::block_on(self.async_run()))
+			.unwrap();
+
+		child.join().unwrap()
+	}
+
+	async fn async_run(self) {
+		if !self.options.normative.unwrap_or(true) {
+			log::warn!("ignoring test `{}` (non normative)", self.name);
+			return;
+		}
+
+		if self.options.spec_version == Some("json-ld-1.0") {
+			log::warn!("ignoring test `{}` (unsupported spec version)", self.name);
+			return;
+		}
+
+		for comment in self.comments {
+			println!("{}", comment)
+		}
+
+		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
+		let mut loader: json_ld::FsLoader = json_ld::FsLoader::default();
+		loader.mount(
+			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api").into()),
+			"json-ld-api",
+		);
+
+		let mut options: json_ld::Options = json_ld::Options::default();
+		if let Some(p) = self.options.processing_mode {
+			options.processing_mode = p
+		}
+
+		options.base = self.options.base.map(|iri| vocabulary.insert(iri));
+		options.expand_context = self
+			.options
+			.expand_context
+			.map(|iri| RemoteDocumentReference::Iri(vocabulary.insert(iri)));
+		options.rdf_direction = self.options.rdf_direction;
+		options.produce_generalized_rdf = self.options.produce_generalized_rdf;
+
+		let input = vocabulary.insert(self.input);
+
+		match self.desc {
+			to_rdf::Description::Positive { expect } => {
+				let json_ld = loader.load_with(&mut vocabulary, input).await.unwrap();
+
+				let mut generator = rdf_types::generator::Blank::new_with_prefix("b".to_string())
+					.with_metadata(locspan::Location::new(input, locspan::Span::default()));
+				let mut to_rdf = json_ld
+					.to_rdf_full(&mut vocabulary, &mut generator, &mut loader, options, ())
+					.await
+					.unwrap();
+
+				let dataset: grdf::HashDataset<_, _, _, _> = to_rdf
+					.quads()
+					.cloned()
+					.map(|rdf_types::Quad(s, p, o, g)| {
+						rdf_types::Quad(
+							s.into_term(),
+							p.into_term(),
+							o,
+							g.map(rdf_types::Subject::into_term),
+						)
+					})
+					.collect();
+
+				let expect_url = vocabulary.insert(expect);
+				let expected_content =
+					std::fs::read_to_string(loader.filepath(&vocabulary, &expect_url).unwrap())
+						.unwrap();
+				let expected_dataset: grdf::HashDataset<_, _, _, _> =
+					nquads_syntax::GrdfDocument::parse_str(&expected_content, |span| span)
+						.unwrap()
+						.into_value()
+						.into_iter()
+						.map(|Meta(q, _)| q.strip().insert_into(&mut vocabulary))
+						.collect();
+
+				let success = dataset.is_isomorphic_to(&expected_dataset);
+
+				if !success {
+					eprintln!("test failed");
+					eprintln!("output=");
+					for q in dataset.into_quads() {
+						eprintln!("{}", q.with(&vocabulary));
+					}
+
+					eprintln!("expected=");
+					for q in expected_dataset.into_quads() {
+						eprintln!("{}", q.with(&vocabulary));
+					}
+				}
+
+				assert!(success)
+			}
+			to_rdf::Description::Negative {
+				expected_error_code,
+			} => {
+				let json_ld = loader.load_with(&mut vocabulary, input).await.unwrap();
+				let result: Result<_, _> = json_ld
+					.expand_full(&mut vocabulary, &mut loader, options, ())
+					.await;
+
+				match result {
+					Ok(expanded) => {
+						eprintln!("output=\n{}", expanded.with(&vocabulary).pretty_print());
+						panic!(
+							"expansion succeeded when it should have failed with `{}`",
+							expected_error_code
+						)
+					}
+					Err(_e) => {
+						// TODO improve error codes.
+						// assert_eq!(e.code().as_str(), expected_error_code)
+					}
+				}
+			}
+			to_rdf::Description::PositiveSyntax {} => {
+				// ...
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds the `JsonLdProcessor::to_rdf*` function family, and the `toRdf` test suite.