### PR TITLE
Version 0.11, upgrade `json-syntax` to 0.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0]
+- Upgraded `json_syntax`: 0.8.17 -> 0.9
+  This version adds a better support for `serde` and `serde_json`,
+  but changes the behavior of the `json` macro without metadata annotations to
+  simplify type inference.
+
 ## [0.10.0]
 ### Changed
 - Use `rdf_types::Literal` instead of `json_ld::rdf::Value`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Timothée Haudebourg <timothee@haudebourg.net>"]
 categories = ["web-programming", "database", "data-structures"]
@@ -21,14 +21,14 @@ repository = "https://github.com/timothee-haudebourg/json-ld"
 license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
-json-ld = { path = "json-ld", version = "0.10.0" }
-json-ld-syntax = { path = "syntax", version = "0.10.0" }
-json-ld-core = { path = "core", version = "0.10.0" }
-json-ld-context-processing = { path = "context-processing", version = "0.10.0" }
-json-ld-expansion = { path = "expansion", version = "0.10.0" }
-json-ld-compaction = { path = "compaction", version = "0.10.0" }
-json-ld-testing = { path = "testing", version = "0.10.0" }
-json-syntax = "0.8.17"
+json-ld = { path = "json-ld", version = "0.11.0" }
+json-ld-syntax = { path = "syntax", version = "0.11.0" }
+json-ld-core = { path = "core", version = "0.11.0" }
+json-ld-context-processing = { path = "context-processing", version = "0.11.0" }
+json-ld-expansion = { path = "expansion", version = "0.11.0" }
+json-ld-compaction = { path = "compaction", version = "0.11.0" }
+json-ld-testing = { path = "testing", version = "0.11.0" }
+json-syntax = "0.9"
 iref = "2.2"
 static-iref = "2"
 langtag = "0.3"


### PR DESCRIPTION
This version adds a better support for `serde` and `serde_json`, but changes the behavior of the `json` macro without metadata annotations to simplify type inference, so it requires a major revision unfortunately.