### PR TITLE
Add support for `wasm32` target.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
 	"cli"
 ]
 
+resolver = "2"
+
 [workspace.package]
 version = "0.15.0"
 edition = "2021"

--- a/compaction/src/document.rs
+++ b/compaction/src/document.rs
@@ -1,6 +1,8 @@
-use futures::FutureExt;
 use json_ld_context_processing::ContextLoader;
-use json_ld_core::{ExpandedDocument, FlattenedDocument, Term};
+use json_ld_core::{
+	future::{BoxFuture, FutureExt},
+	ExpandedDocument, FlattenedDocument, Term,
+};
 use json_ld_syntax::{IntoJson, IntoJsonMeta, Keyword};
 use locspan::Meta;
 use rdf_types::{vocabulary, Vocabulary};
@@ -53,7 +55,7 @@ pub trait CompactMeta<I, B, M> {
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B, C, M>,
 		loader: &'a mut L,
 		options: crate::Options,
-	) -> futures::future::BoxFuture<'a, CompactDocumentResult<I, M, L>>
+	) -> BoxFuture<'a, CompactDocumentResult<I, M, L>>
 	where
 		N: Send + Sync + rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq + Send + Sync,
@@ -78,7 +80,7 @@ pub trait Compact<I, B, M> {
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B, C, M>,
 		loader: &'a mut L,
 		options: crate::Options,
-	) -> futures::future::BoxFuture<'a, CompactDocumentResult<I, M, L>>
+	) -> BoxFuture<'a, CompactDocumentResult<I, M, L>>
 	where
 		N: Send + Sync + rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq + Send + Sync,
@@ -100,7 +102,7 @@ pub trait Compact<I, B, M> {
 		vocabulary: &'a mut N,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B, C, M>,
 		loader: &'a mut L,
-	) -> futures::future::BoxFuture<'a, CompactDocumentResult<I, M, L>>
+	) -> BoxFuture<'a, CompactDocumentResult<I, M, L>>
 	where
 		N: Send + Sync + rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq + Send + Sync,
@@ -122,7 +124,7 @@ pub trait Compact<I, B, M> {
 		&'a self,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B, C, M>,
 		loader: &'a mut L,
-	) -> futures::future::BoxFuture<'a, CompactDocumentResult<I, M, L>>
+	) -> BoxFuture<'a, CompactDocumentResult<I, M, L>>
 	where
 		(): Send + Sync + rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq + Send + Sync,
@@ -148,7 +150,7 @@ impl<T: CompactMeta<I, B, M>, I, B, M> Compact<I, B, M> for Meta<T, M> {
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B, C, M>,
 		loader: &'a mut L,
 		options: crate::Options,
-	) -> futures::future::BoxFuture<'a, CompactDocumentResult<I, M, L>>
+	) -> BoxFuture<'a, CompactDocumentResult<I, M, L>>
 	where
 		N: Send + Sync + rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq + Send + Sync,
@@ -176,7 +178,7 @@ impl<I, B, M> CompactMeta<I, B, M> for ExpandedDocument<I, B, M> {
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B, C, M>,
 		loader: &'a mut L,
 		options: crate::Options,
-	) -> futures::future::BoxFuture<'a, CompactDocumentResult<I, M, L>>
+	) -> BoxFuture<'a, CompactDocumentResult<I, M, L>>
 	where
 		N: Send + Sync + rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq + Send + Sync,
@@ -225,7 +227,7 @@ impl<I, B, M> CompactMeta<I, B, M> for FlattenedDocument<I, B, M> {
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B, C, M>,
 		loader: &'a mut L,
 		options: crate::Options,
-	) -> futures::future::BoxFuture<'a, CompactDocumentResult<I, M, L>>
+	) -> BoxFuture<'a, CompactDocumentResult<I, M, L>>
 	where
 		N: Send + Sync + rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq + Send + Sync,

--- a/compaction/src/lib.rs
+++ b/compaction/src/lib.rs
@@ -4,12 +4,12 @@
 //! # Usage
 //!
 //! The compaction algorithm is provided by the [`Compact`] trait.
-use futures::future::{BoxFuture, FutureExt};
 use json_ld_context_processing::{
 	ContextLoader, Options as ProcessingOptions, Process, ProcessMeta,
 };
 use json_ld_core::{
 	context::inverse::{LangSelection, TypeSelection},
+	future::{BoxFuture, FutureExt},
 	object::Any,
 	Context, Indexed, Loader, ProcessingMode, Term, Value,
 };

--- a/context-processing/src/lib.rs
+++ b/context-processing/src/lib.rs
@@ -1,6 +1,8 @@
 //! JSON-LD context processing types and algorithms.
-use futures::future::{BoxFuture, FutureExt};
-pub use json_ld_core::{warning, Context, ContextLoader, ProcessingMode};
+pub use json_ld_core::{
+	future::{BoxFuture, FutureExt},
+	warning, Context, ContextLoader, ProcessingMode,
+};
 use json_ld_syntax::ErrorCode;
 use locspan::Meta;
 use rdf_types::VocabularyMut;

--- a/context-processing/src/syntax.rs
+++ b/context-processing/src/syntax.rs
@@ -2,9 +2,11 @@ use crate::{
 	ContextLoader, Error, MetaError, Options, ProcessMeta, Processed, ProcessingResult,
 	ProcessingStack, WarningHandler,
 };
-use futures::future::{BoxFuture, FutureExt};
 use iref::IriRef;
-use json_ld_core::{Context, ProcessingMode, Term};
+use json_ld_core::{
+	future::{BoxFuture, FutureExt},
+	Context, ProcessingMode, Term,
+};
 use json_ld_syntax::{self as syntax, Entry, Nullable};
 use locspan::{At, Meta};
 use rdf_types::{IriVocabularyMut, VocabularyMut};

--- a/context-processing/src/syntax/define.rs
+++ b/context-processing/src/syntax/define.rs
@@ -1,9 +1,9 @@
 use super::{expand_iri_simple, expand_iri_with, Merged};
 use crate::{Error, Options, ProcessMeta, ProcessingStack, Warning, WarningHandler};
-use futures::future::{BoxFuture, FutureExt};
 use iref::{Iri, IriRef};
 use json_ld_core::{
 	context::{NormalTermDefinition, TypeTermDefinition},
+	future::{BoxFuture, FutureExt},
 	Container, Context, ContextLoader, Id, ProcessingMode, Term, Type, ValidId,
 };
 use json_ld_syntax::{

--- a/core/src/future.rs
+++ b/core/src/future.rs
@@ -1,0 +1,27 @@
+//! Custom futures for `json-ld` functions.
+//!
+//! This modules defines futures used in this library. In particular it defines
+//! a non-`Send` variant of the `futures::future::BoxFuture` type enabled when
+//! compiling for `wasm32`.
+
+#[cfg(target_arch = "wasm32")]
+mod wasm32 {
+	use std::{future::Future, pin::Pin};
+	pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+	pub trait FutureExt<'a>: Future {
+		fn boxed(self) -> BoxFuture<'a, Self::Output>;
+	}
+
+	impl<'a, F: Future + Sized + 'a> FutureExt<'a> for F {
+		fn boxed(self) -> BoxFuture<'a, Self::Output> {
+			Box::pin(self)
+		}
+	}
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm32::{BoxFuture, FutureExt};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use futures::future::{BoxFuture, FutureExt};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@ mod container;
 pub mod context;
 mod document;
 pub mod flattening;
+pub mod future;
 pub mod id;
 mod indexed;
 mod lang_string;

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1,4 +1,4 @@
-use futures::future::{BoxFuture, FutureExt};
+use crate::future::{BoxFuture, FutureExt};
 use hashbrown::HashSet;
 use iref::Iri;
 use locspan::{Location, MapLocErr, Meta};

--- a/core/src/loader/fs.rs
+++ b/core/src/loader/fs.rs
@@ -1,5 +1,5 @@
 use super::{Loader, RemoteDocument};
-use futures::future::{BoxFuture, FutureExt};
+use crate::future::{BoxFuture, FutureExt};
 use locspan::Meta;
 use rdf_types::{vocabulary::IriIndex, IriVocabulary};
 use std::collections::HashMap;

--- a/core/src/loader/none.rs
+++ b/core/src/loader/none.rs
@@ -1,6 +1,6 @@
 use super::{Loader, RemoteDocument};
+use crate::future::{BoxFuture, FutureExt};
 use contextual::{DisplayWithContext, WithContext};
-use futures::future::{BoxFuture, FutureExt};
 use rdf_types::{vocabulary::IriIndex, IriVocabulary};
 use std::fmt;
 use std::marker::PhantomData;

--- a/core/src/loader/reqwest.rs
+++ b/core/src/loader/reqwest.rs
@@ -2,8 +2,8 @@
 use crate::Profile;
 
 use super::{Loader, RemoteDocument};
+use crate::future::{BoxFuture, FutureExt};
 use bytes::Bytes;
-use futures::future::{BoxFuture, FutureExt};
 use hashbrown::HashSet;
 use iref::Iri;
 use locspan::{Meta, Span};

--- a/expansion/src/element.rs
+++ b/expansion/src/element.rs
@@ -2,11 +2,13 @@ use crate::{
 	expand_array, expand_iri, expand_literal, expand_node, expand_value, Error, Expanded,
 	GivenLiteralValue, LiteralValue, Loader, Options, Warning, WarningHandler,
 };
-use futures::future::{BoxFuture, FutureExt};
 use json_ld_context_processing::{
 	ContextLoader, Options as ProcessingOptions, Process, ProcessMeta,
 };
-use json_ld_core::{object, Context, Id, Indexed, Object, Term, ValidId};
+use json_ld_core::{
+	future::{BoxFuture, FutureExt},
+	object, Context, Id, Indexed, Object, Term, ValidId,
+};
 use json_ld_syntax::{Keyword, Nullable};
 use json_syntax::{object::Entry, Value};
 use locspan::{At, MapLocErr, Meta};

--- a/expansion/src/lib.rs
+++ b/expansion/src/lib.rs
@@ -6,9 +6,11 @@
 //! The expansion algorithm is provided by the [`Expand`] trait.
 use std::hash::Hash;
 
-use futures::future::{BoxFuture, FutureExt};
 use json_ld_context_processing::{Context, ProcessMeta};
-use json_ld_core::{ContextLoader, ExpandedDocument, Loader, RemoteDocument};
+use json_ld_core::{
+	future::{BoxFuture, FutureExt},
+	ContextLoader, ExpandedDocument, Loader, RemoteDocument,
+};
 use json_syntax::Value;
 use locspan::Meta;
 use rdf_types::{vocabulary, BlankIdVocabulary, VocabularyMut};

--- a/expansion/src/node.rs
+++ b/expansion/src/node.rs
@@ -3,11 +3,11 @@ use crate::{
 	Expanded, ExpandedEntry, LiteralValue, Loader, Options, Policy, Warning, WarningHandler,
 };
 use contextual::WithContext;
-use futures::future::{BoxFuture, FutureExt};
 use json_ld_context_processing::{
 	ContextLoader, Options as ProcessingOptions, Process, ProcessMeta,
 };
 use json_ld_core::{
+	future::{BoxFuture, FutureExt},
 	object,
 	object::value::{Literal, LiteralString},
 	Container, Context, Id, Indexed, IndexedObject, LangString, Node, Object, ProcessingMode, Term,

--- a/json-ld/src/processor.rs
+++ b/json-ld/src/processor.rs
@@ -3,11 +3,11 @@ use crate::context_processing::{self, Process, ProcessMeta, Processed};
 use crate::expansion;
 use crate::syntax::{self, ErrorCode};
 use crate::{
-	flattening::ConflictingIndexes, id::Generator, Context, ContextLoader, ExpandedDocument,
-	Loader, ProcessingMode, RemoteDocumentReference,
+	flattening::ConflictingIndexes,
+	future::{BoxFuture, FutureExt},
+	id::Generator,
+	Context, ContextLoader, ExpandedDocument, Loader, ProcessingMode, RemoteDocumentReference,
 };
-use futures::future::BoxFuture;
-use futures::FutureExt;
 use json_ld_core::rdf::RdfDirection;
 use json_ld_core::RdfQuads;
 use locspan::{Location, Meta};

--- a/json-ld/src/processor/remote_document.rs
+++ b/json-ld/src/processor/remote_document.rs
@@ -6,10 +6,11 @@ use crate::context_processing::{self, Process, ProcessMeta};
 use crate::expansion::{self, Expand};
 use crate::syntax;
 use crate::{
-	id::Generator, Context, ContextLoader, Flatten, Loader, RemoteDocument, RemoteDocumentReference,
+	future::{BoxFuture, FutureExt},
+	id::Generator,
+	Context, ContextLoader, Flatten, Loader, RemoteDocument, RemoteDocumentReference,
 };
 use contextual::WithContext;
-use futures::future::{BoxFuture, FutureExt};
 use locspan::BorrowStripped;
 use rdf_types::VocabularyMut;
 use std::hash::Hash;

--- a/syntax/src/lib.rs
+++ b/syntax/src/lib.rs
@@ -12,6 +12,7 @@ mod into_json;
 mod keyword;
 mod lang;
 mod nullable;
+#[allow(hidden_glob_reexports)] // Fixed in the next version.
 mod print;
 mod try_from_json;
 


### PR DESCRIPTION
The return type of asynchronous recursive functions and trait methods cannot be named in Rust, at least until both `return_type_notation` and async fn in traits are implemented/stabilized ([it was planned for 2023](https://blog.rust-lang.org/inside-rust/2023/05/03/stabilizing-async-fn-in-trait.html), but I seems it will take more time).

In the meantime, `json-ld` uses `BoxFuture<T> = Box<dyn Future<Output = T>>` provided by the `futures` library to put the future on the head and abstract its properties. We only require `Send`, which is implemented by all futures that normally interact with the library... unless WASM is the target, in which case nothing is `Send`. To solve this issue this PR redefines the `BoxFuture` type when the target is `wasm32` to remove the `Send` bound.