### PR TITLE
`ReqwestLoader` improvements

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [features]
 default = []
-reqwest = ["bytes", "dep:reqwest", "utf8-decode"]
+reqwest = ["bytes", "dep:reqwest", "utf8-decode", "reqwest-middleware"]
 serde = ["dep:serde", "json-syntax/serde"]
 
 [dependencies]
@@ -40,6 +40,7 @@ pretty_dtoa = "0.3"
 mime = "0.3"
 
 # For the reqwest loader
-reqwest = { version = "^0.11", optional = true }
-bytes = { version = "^1.3", optional = true }
+reqwest = { version = "0.12", optional = true }
+reqwest-middleware = { version = "0.3", optional = true }
+bytes = { version = "1.3", optional = true }
 utf8-decode = { version = "1.0.1", optional = true }

--- a/crates/core/src/context/definition.rs
+++ b/crates/core/src/context/definition.rs
@@ -111,9 +111,9 @@ impl<T, B> Definitions<T, B> {
 	}
 
 	/// Returns a reference to the definition of the given `term`, if any.
-	pub fn get<Q: ?Sized>(&self, term: &Q) -> Option<TermDefinitionRef<T, B>>
+	pub fn get<Q>(&self, term: &Q) -> Option<TermDefinitionRef<T, B>>
 	where
-		Q: Hash + Eq,
+		Q: ?Sized + Hash + Eq,
 		Key: Borrow<Q>,
 		KeywordType: Borrow<Q>,
 	{
@@ -125,9 +125,9 @@ impl<T, B> Definitions<T, B> {
 	}
 
 	/// Returns a reference to the normal definition of the given `term`, if any.
-	pub fn get_normal<Q: ?Sized>(&self, term: &Q) -> Option<&NormalTermDefinition<T, B>>
+	pub fn get_normal<Q>(&self, term: &Q) -> Option<&NormalTermDefinition<T, B>>
 	where
-		Q: Hash + Eq,
+		Q: ?Sized + Hash + Eq,
 		Key: Borrow<Q>,
 	{
 		self.normal.get(term)
@@ -138,9 +138,9 @@ impl<T, B> Definitions<T, B> {
 		self.type_.as_ref()
 	}
 
-	pub fn contains_term<Q: ?Sized>(&self, term: &Q) -> bool
+	pub fn contains_term<Q>(&self, term: &Q) -> bool
 	where
-		Q: Hash + Eq,
+		Q: ?Sized + Hash + Eq,
 		Key: Borrow<Q>,
 		KeywordType: Borrow<Q>,
 	{

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -72,20 +72,20 @@ impl<T, B> Context<T, B> {
 	}
 
 	/// Returns a reference to the given `term` definition, if any.
-	pub fn get<Q: ?Sized>(&self, term: &Q) -> Option<TermDefinitionRef<T, B>>
+	pub fn get<Q>(&self, term: &Q) -> Option<TermDefinitionRef<T, B>>
 	where
 		Key: Borrow<Q>,
 		KeywordType: Borrow<Q>,
-		Q: Hash + Eq,
+		Q: ?Sized + Hash + Eq,
 	{
 		self.definitions.get(term)
 	}
 
 	/// Returns a reference to the given `term` normal definition, if any.
-	pub fn get_normal<Q: ?Sized>(&self, term: &Q) -> Option<&NormalTermDefinition<T, B>>
+	pub fn get_normal<Q>(&self, term: &Q) -> Option<&NormalTermDefinition<T, B>>
 	where
 		Key: Borrow<Q>,
-		Q: Hash + Eq,
+		Q: ?Sized + Hash + Eq,
 	{
 		self.definitions.get_normal(term)
 	}
@@ -96,11 +96,11 @@ impl<T, B> Context<T, B> {
 	}
 
 	/// Checks if the given `term` is defined.
-	pub fn contains_term<Q: ?Sized>(&self, term: &Q) -> bool
+	pub fn contains_term<Q>(&self, term: &Q) -> bool
 	where
 		Key: Borrow<Q>,
 		KeywordType: Borrow<Q>,
-		Q: Hash + Eq,
+		Q: ?Sized + Hash + Eq,
 	{
 		self.definitions.contains_term(term)
 	}

--- a/crates/core/src/rdf/mod.rs
+++ b/crates/core/src/rdf/mod.rs
@@ -132,14 +132,14 @@ pub struct CompoundLiteral<T, B, L> {
 }
 
 impl<T: Clone> crate::object::Value<T> {
-	fn rdf_value_with<V: Vocabulary<Iri = T> + IriVocabularyMut, G: Generator<V>>(
+	fn rdf_value_with<V, G: Generator<V>>(
 		&self,
 		vocabulary: &mut V,
 		generator: &mut G,
 		rdf_direction: Option<RdfDirection>,
 	) -> Option<CompoundLiteral<T, V::BlankId, V::Literal>>
 	where
-		V: LiteralVocabularyMut,
+		V: Vocabulary<Iri = T> + IriVocabularyMut + LiteralVocabularyMut,
 	{
 		match self {
 			Self::Json(json) => {
@@ -299,14 +299,14 @@ impl<T: Clone, B: Clone> Node<T, B> {
 }
 
 impl<T: Clone, B: Clone> Object<T, B> {
-	fn rdf_value_with<V: Vocabulary<Iri = T, BlankId = B> + IriVocabularyMut, G: Generator<V>>(
+	fn rdf_value_with<V, G: Generator<V>>(
 		&self,
 		vocabulary: &mut V,
 		generator: &mut G,
 		rdf_direction: Option<RdfDirection>,
 	) -> Option<CompoundValue<T, B, V::Literal>>
 	where
-		V: LiteralVocabularyMut,
+		V: Vocabulary<Iri = T, BlankId = B> + IriVocabularyMut + LiteralVocabularyMut,
 	{
 		match self {
 			Self::Value(value) => value
@@ -346,14 +346,14 @@ pub struct CompoundValue<'a, T, B, L> {
 }
 
 impl<'a, T: Clone, B: Clone> crate::quad::ObjectRef<'a, T, B> {
-	pub fn rdf_value_with<V: Vocabulary<Iri = T, BlankId = B> + IriVocabularyMut, G: Generator<V>>(
+	pub fn rdf_value_with<V, G: Generator<V>>(
 		&self,
 		vocabulary: &mut V,
 		generator: &mut G,
 		rdf_direction: Option<RdfDirection>,
 	) -> Option<CompoundValue<'a, T, B, V::Literal>>
 	where
-		V: LiteralVocabularyMut,
+		V: Vocabulary<Iri = T, BlankId = B> + IriVocabularyMut + LiteralVocabularyMut,
 	{
 		match self {
 			Self::Object(object) => object.rdf_value_with(vocabulary, generator, rdf_direction),
@@ -447,10 +447,7 @@ impl<'a, T, B, L> CompoundValueTriples<'a, T, B, L> {
 		}
 	}
 
-	pub fn next<
-		V: Vocabulary<Iri = T, BlankId = B, Literal = L> + IriVocabularyMut,
-		G: Generator<V>,
-	>(
+	pub fn next<V, G: Generator<V>>(
 		&mut self,
 		vocabulary: &mut V,
 		generator: &mut G,
@@ -460,7 +457,7 @@ impl<'a, T, B, L> CompoundValueTriples<'a, T, B, L> {
 		T: Clone,
 		B: Clone,
 		L: Clone,
-		V: LiteralVocabularyMut,
+		V: Vocabulary<Iri = T, BlankId = B, Literal = L> + IriVocabularyMut + LiteralVocabularyMut,
 	{
 		match self {
 			Self::Literal(l) => l.next(vocabulary),
@@ -527,10 +524,7 @@ impl<'a, T, B, L> ListTriples<'a, T, B, L> {
 		}
 	}
 
-	pub fn next<
-		V: Vocabulary<Iri = T, BlankId = B, Literal = L> + IriVocabularyMut,
-		G: Generator<V>,
-	>(
+	pub fn next<V, G: Generator<V>>(
 		&mut self,
 		vocabulary: &mut V,
 		generator: &mut G,
@@ -540,7 +534,7 @@ impl<'a, T, B, L> ListTriples<'a, T, B, L> {
 		T: Clone,
 		B: Clone,
 		L: Clone,
-		V: LiteralVocabularyMut,
+		V: Vocabulary<Iri = T, BlankId = B, Literal = L> + IriVocabularyMut + LiteralVocabularyMut,
 	{
 		loop {
 			if let Some(pending) = self.pending.take() {

--- a/crates/serialization/src/expanded/node.rs
+++ b/crates/serialization/src/expanded/node.rs
@@ -19,13 +19,13 @@ use super::{
 
 /// Serialize the given Linked-Data value into a JSON-LD node object using a
 /// custom vocabulary and interpretation.
-pub fn serialize_node_with<I: Interpretation, V: Vocabulary, T>(
+pub fn serialize_node_with<I, V, T>(
 	vocabulary: &mut V,
 	interpretation: &mut I,
 	value: &T,
 ) -> Result<Node<V::Iri, V::BlankId>, Error>
 where
-	V: IriVocabularyMut,
+	V: Vocabulary + IriVocabularyMut,
 	V::Iri: Clone + Eq + Hash,
 	V::BlankId: Clone + Eq + Hash,
 	I: ReverseIriInterpretation<Iri = V::Iri>

--- a/crates/serialization/src/expanded/object.rs
+++ b/crates/serialization/src/expanded/object.rs
@@ -30,13 +30,13 @@ use super::{
 
 /// Serialize the given Linked-Data value into a JSON-LD object using a
 /// custom vocabulary and interpretation.
-pub fn serialize_object_with<I: Interpretation, V: Vocabulary, T>(
+pub fn serialize_object_with<I, V, T>(
 	vocabulary: &mut V,
 	interpretation: &mut I,
 	value: &T,
 ) -> Result<Object<V::Iri, V::BlankId>, Error>
 where
-	V: IriVocabularyMut,
+	V: Vocabulary + IriVocabularyMut,
 	V::Iri: Clone + Eq + Hash,
 	V::BlankId: Clone + Eq + Hash,
 	I: ReverseIriInterpretation<Iri = V::Iri>

--- a/crates/serialization/src/lib.rs
+++ b/crates/serialization/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate implements JSON-LD serialization (from RDF dataset to JSON-LD)
 //! through the [`linked_data`](https://github.com/spruceid/linked-data-rs)
 //! crate.
-//! The input value can be an RDF dataset, or any type implementing 
+//! The input value can be an RDF dataset, or any type implementing
 //! [`linked_data::LinkedData`].
 use std::hash::Hash;
 
@@ -47,16 +47,17 @@ pub fn serialize(value: &impl LinkedData) -> Result<ExpandedDocument, Error> {
 
 /// Serialize the given Linked-Data value into a JSON-LD document using a
 /// custom vocabulary and interpretation.
-pub fn serialize_with<V: Vocabulary, I: Interpretation>(
+pub fn serialize_with<V, I>(
 	vocabulary: &mut V,
 	interpretation: &mut I,
 	value: &impl LinkedData<I, V>,
 ) -> Result<ExpandedDocument<V::Iri, V::BlankId>, Error>
 where
-	V: IriVocabularyMut,
+	V: Vocabulary + IriVocabularyMut,
 	V::Iri: Clone + Eq + Hash,
 	V::BlankId: Clone + Eq + Hash,
-	I: ReverseIriInterpretation<Iri = V::Iri>
+	I: Interpretation
+		+ ReverseIriInterpretation<Iri = V::Iri>
 		+ ReverseBlankIdInterpretation<BlankId = V::BlankId>
 		+ ReverseLiteralInterpretation<Literal = V::Literal>,
 {


### PR DESCRIPTION
This PR adds a `client` option to the `ReqwestLoader` allowing one to use its own `reqwest` configuration and middleware using the [`reqwest-middleware`](https://crates.io/crates/reqwest-middleware) library, fixing #68.

The client is now assumed to be dealing with redirections, fixing #69.