### PR TITLE
Remove generics on error types.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[env]
-# Set the minimum stack size to 3MB.
-RUST_MIN_STACK = "3145728"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+# Set the minimum stack size to 3MB.
+RUST_MIN_STACK = "3145728"

--- a/crates/compaction/src/document.rs
+++ b/crates/compaction/src/document.rs
@@ -8,8 +8,7 @@ use crate::{
 	CompactFragment,
 };
 
-pub type CompactDocumentResult<I, L> =
-	Result<json_syntax::Value, crate::Error<<L as Loader<I>>::Error>>;
+pub type CompactDocumentResult = Result<json_syntax::Value, crate::Error>;
 
 /// Context embeding method.
 ///
@@ -41,7 +40,7 @@ pub trait Compact<I, B> {
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
 		loader: &'a mut L,
 		options: crate::Options,
-	) -> CompactDocumentResult<I, L>
+	) -> CompactDocumentResult
 	where
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -56,7 +55,7 @@ pub trait Compact<I, B> {
 		vocabulary: &'a mut N,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
 		loader: &'a mut L,
-	) -> CompactDocumentResult<I, L>
+	) -> CompactDocumentResult
 	where
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -73,7 +72,7 @@ pub trait Compact<I, B> {
 		&'a self,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
 		loader: &'a mut L,
-	) -> CompactDocumentResult<I, L>
+	) -> CompactDocumentResult
 	where
 		(): rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -92,7 +91,7 @@ impl<I, B> Compact<I, B> for ExpandedDocument<I, B> {
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
 		loader: &'a mut L,
 		options: crate::Options,
-	) -> CompactDocumentResult<I, L>
+	) -> CompactDocumentResult
 	where
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -124,7 +123,7 @@ impl<I, B> Compact<I, B> for FlattenedDocument<I, B> {
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
 		loader: &'a mut L,
 		options: crate::Options,
-	) -> CompactDocumentResult<I, L>
+	) -> CompactDocumentResult
 	where
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,

--- a/crates/compaction/src/lib.rs
+++ b/crates/compaction/src/lib.rs
@@ -30,7 +30,7 @@ use property::*;
 use value::*;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error<E> {
+pub enum Error {
 	#[error("IRI confused with prefix")]
 	IriConfusedWithPrefix,
 
@@ -38,10 +38,10 @@ pub enum Error<E> {
 	InvalidNestValue,
 
 	#[error("Context processing failed: {0}")]
-	ContextProcessing(json_ld_context_processing::Error<E>),
+	ContextProcessing(json_ld_context_processing::Error),
 }
 
-impl<E> Error<E> {
+impl Error {
 	pub fn code(&self) -> ErrorCode {
 		match self {
 			Self::IriConfusedWithPrefix => ErrorCode::IriConfusedWithPrefix,
@@ -51,19 +51,19 @@ impl<E> Error<E> {
 	}
 }
 
-impl<E> From<json_ld_context_processing::Error<E>> for Error<E> {
-	fn from(e: json_ld_context_processing::Error<E>) -> Self {
+impl From<json_ld_context_processing::Error> for Error {
+	fn from(e: json_ld_context_processing::Error) -> Self {
 		Self::ContextProcessing(e)
 	}
 }
 
-impl<E> From<IriConfusedWithPrefix> for Error<E> {
+impl From<IriConfusedWithPrefix> for Error {
 	fn from(_: IriConfusedWithPrefix) -> Self {
 		Self::IriConfusedWithPrefix
 	}
 }
 
-pub type CompactFragmentResult<I, L> = Result<json_syntax::Value, Error<<L as Loader<I>>::Error>>;
+pub type CompactFragmentResult = Result<json_syntax::Value, Error>;
 
 /// Compaction options.
 #[derive(Clone, Copy)]
@@ -132,7 +132,7 @@ pub trait CompactFragment<I, B> {
 		active_property: Option<&'a str>,
 		loader: &'a mut L,
 		options: Options,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -146,7 +146,7 @@ pub trait CompactFragment<I, B> {
 		vocabulary: &'a mut N,
 		active_context: &'a Context<I, B>,
 		loader: &'a mut L,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -170,7 +170,7 @@ pub trait CompactFragment<I, B> {
 		&'a self,
 		active_context: &'a Context<I, B>,
 		loader: &'a mut L,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		(): VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -207,7 +207,7 @@ pub trait CompactIndexedFragment<I, B> {
 		active_property: Option<&'a str>,
 		loader: &'a mut L,
 		options: Options,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -224,7 +224,7 @@ impl<I, B, T: CompactIndexedFragment<I, B>> CompactFragment<I, B> for Indexed<T>
 		active_property: Option<&'a str>,
 		loader: &'a mut L,
 		options: Options,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -255,7 +255,7 @@ impl<I, B, T: Any<I, B>> CompactIndexedFragment<I, B> for T {
 		active_property: Option<&'a str>,
 		loader: &'a mut L,
 		options: Options,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -454,7 +454,7 @@ async fn compact_collection_with<'a, N, L, O, T>(
 	active_property: Option<&'a str>,
 	loader: &'a mut L,
 	options: Options,
-) -> CompactFragmentResult<N::Iri, L>
+) -> CompactFragmentResult
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,
@@ -515,7 +515,7 @@ impl<T: CompactFragment<I, B>, I, B> CompactFragment<I, B> for IndexSet<T> {
 		active_property: Option<&'a str>,
 		loader: &'a mut L,
 		options: Options,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -544,7 +544,7 @@ impl<T: CompactFragment<I, B>, I, B> CompactFragment<I, B> for Vec<T> {
 		active_property: Option<&'a str>,
 		loader: &'a mut L,
 		options: Options,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
@@ -573,7 +573,7 @@ impl<T: CompactFragment<I, B> + Send + Sync, I, B> CompactFragment<I, B> for [T]
 		active_property: Option<&'a str>,
 		loader: &'a mut L,
 		options: Options,
-	) -> CompactFragmentResult<I, L>
+	) -> CompactFragmentResult
 	where
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,

--- a/crates/compaction/src/node.rs
+++ b/crates/compaction/src/node.rs
@@ -23,7 +23,7 @@ pub async fn compact_indexed_node_with<N, L>(
 	active_property: Option<&str>,
 	loader: &mut L,
 	options: Options,
-) -> Result<json_syntax::Value, Error<L::Error>>
+) -> Result<json_syntax::Value, Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,
@@ -370,14 +370,14 @@ where
 }
 
 /// Compact the given list of types into the given `result` compacted object.
-fn compact_types<N, E>(
+fn compact_types<N>(
 	vocabulary: &mut N,
 	result: &mut json_syntax::Object,
 	types: Option<&[Id<N::Iri, N::BlankId>]>,
 	active_context: &Context<N::Iri, N::BlankId>,
 	type_scoped_context: &Context<N::Iri, N::BlankId>,
 	options: Options,
-) -> Result<(), Error<E>>
+) -> Result<(), Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,

--- a/crates/compaction/src/property.rs
+++ b/crates/compaction/src/property.rs
@@ -24,7 +24,7 @@ async fn compact_property_list<N, L>(
 	active_context: &Context<N::Iri, N::BlankId>,
 	loader: &mut L,
 	options: Options,
-) -> Result<(), Error<L::Error>>
+) -> Result<(), Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,
@@ -109,7 +109,7 @@ async fn compact_property_graph<N, L>(
 	active_context: &Context<N::Iri, N::BlankId>,
 	loader: &mut L,
 	options: Options,
-) -> Result<(), Error<L::Error>>
+) -> Result<(), Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,
@@ -300,12 +300,12 @@ where
 	Ok(())
 }
 
-fn select_nest_result<'a, I, B, E>(
+fn select_nest_result<'a, I, B>(
 	result: &'a mut json_syntax::Object,
 	active_context: &Context<I, B>,
 	item_active_property: &str,
 	compact_arrays: bool,
-) -> Result<(&'a mut json_syntax::Object, Container, bool), Error<E>>
+) -> Result<(&'a mut json_syntax::Object, Container, bool), Error>
 where
 	I: Clone + Hash + Eq,
 	B: Clone + Hash + Eq,
@@ -392,7 +392,7 @@ pub async fn compact_property<'a, N, L, O, T>(
 	loader: &mut L,
 	inside_reverse: bool,
 	options: Options,
-) -> Result<(), Error<L::Error>>
+) -> Result<(), Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,

--- a/crates/compaction/src/value.rs
+++ b/crates/compaction/src/value.rs
@@ -15,7 +15,7 @@ pub async fn compact_indexed_value_with<N, L>(
 	active_property: Option<&str>,
 	loader: &mut L,
 	options: Options,
-) -> Result<json_syntax::Value, Error<L::Error>>
+) -> Result<json_syntax::Value, Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,

--- a/crates/context-processing/src/algorithm/define.rs
+++ b/crates/context-processing/src/algorithm/define.rs
@@ -55,7 +55,7 @@ impl DefinedTerms {
 		Self::default()
 	}
 
-	pub fn begin<E>(&mut self, key: &KeyOrKeyword) -> Result<bool, Error<E>> {
+	pub fn begin(&mut self, key: &KeyOrKeyword) -> Result<bool, Error> {
 		match self.0.get(key) {
 			Some(d) => {
 				if d.pending {
@@ -81,8 +81,6 @@ pub struct DefinedTerm {
 	pending: bool,
 }
 
-pub type DefineResult<E> = Result<(), Error<E>>;
-
 /// Follows the `https://www.w3.org/TR/json-ld11-api/#create-term-definition` algorithm.
 /// Default value for `base_url` is `None`. Default values for `protected` and `override_protected` are `false`.
 #[allow(clippy::too_many_arguments)]
@@ -96,7 +94,7 @@ pub async fn define<'a, N, L, W>(
 	base_url: Option<N::Iri>,
 	protected: bool,
 	options: Options,
-) -> DefineResult<L::Error>
+) -> Result<(), Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + PartialEq,

--- a/crates/context-processing/src/algorithm/iri.rs
+++ b/crates/context-processing/src/algorithm/iri.rs
@@ -16,7 +16,7 @@ impl From<MalformedIri> for Warning {
 }
 
 /// Result of the [`expand_iri_with`] function.
-pub type ExpandIriResult<T, B, E> = Result<Term<T, B>, Error<E>>;
+pub type ExpandIriResult<T, B> = Result<Term<T, B>, Error>;
 
 /// Default values for `document_relative` and `vocab` should be `false` and `true`.
 #[allow(clippy::too_many_arguments)]
@@ -30,7 +30,7 @@ pub async fn expand_iri_with<'a, N, L, W>(
 	defined: &'a mut DefinedTerms,
 	remote_contexts: ProcessingStack<N::Iri>,
 	options: Options,
-) -> ExpandIriResult<N::Iri, N::BlankId, L::Error>
+) -> ExpandIriResult<N::Iri, N::BlankId>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + PartialEq,

--- a/crates/core/src/loader/chain.rs
+++ b/crates/core/src/loader/chain.rs
@@ -1,4 +1,5 @@
-use crate::LoadingResult;
+use crate::{LoaderError, LoadingResult};
+use iref::IriBuf;
 use rdf_types::vocabulary::IriVocabularyMut;
 use std::fmt;
 
@@ -50,8 +51,17 @@ pub struct Error<E1, E2>(E1, E2);
 impl<E1: fmt::Display, E2: fmt::Display> fmt::Display for Error<E1, E2> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let Error(e1, e2) = self;
-		write!(f, "First: {e1} / Second: {e2}")
+		write!(f, "{e1}, then {e2}")
 	}
 }
 
 impl<E1: std::error::Error, E2: std::error::Error> std::error::Error for Error<E1, E2> {}
+
+impl<E1: LoaderError, E2: LoaderError> LoaderError for Error<E1, E2> {
+	fn into_iri_and_message(self) -> (IriBuf, String) {
+		let (iri, m1) = self.0.into_iri_and_message();
+		let (_, m2) = self.1.into_iri_and_message();
+
+		(iri, format!("{m1}, then {m2}"))
+	}
+}

--- a/crates/core/src/loader/fs.rs
+++ b/crates/core/src/loader/fs.rs
@@ -59,10 +59,7 @@ impl<I> FsLoader<I> {
 		let url = vocabulary.iri(url).unwrap();
 		for (path, target_url) in &self.mount_points {
 			let target_url = vocabulary.iri(target_url).unwrap().as_iri_ref();
-			if let Some((suffix, _, _)) = url
-				.as_iri_ref()
-				.suffix(target_url)
-			{
+			if let Some((suffix, _, _)) = url.as_iri_ref().suffix(target_url) {
 				let mut filepath = path.clone();
 				for seg in suffix.as_path().segments() {
 					filepath.push(seg.as_str())

--- a/crates/core/src/loader/map.rs
+++ b/crates/core/src/loader/map.rs
@@ -1,5 +1,6 @@
 use super::{Loader, RemoteDocument};
-use crate::LoadingResult;
+use crate::{LoaderError, LoadingResult};
+use iref::IriBuf;
 use rdf_types::vocabulary::IriVocabulary;
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
@@ -8,32 +9,38 @@ use std::hash::Hash;
 /// requested document is not found.
 #[derive(Debug, thiserror::Error)]
 #[error("document `{0}` not found")]
-pub struct EntryNotFound<I>(pub I);
+pub struct EntryNotFound(pub IriBuf);
+
+impl LoaderError for EntryNotFound {
+	fn into_iri_and_message(self) -> (IriBuf, String) {
+		(self.0, "not found".to_string())
+	}
+}
 
 impl<I: Clone + Eq + Hash> Loader<I> for HashMap<I, RemoteDocument<I>> {
-	type Error = EntryNotFound<I>;
+	type Error = EntryNotFound;
 
-	async fn load_with<V>(&mut self, _vocabulary: &mut V, url: I) -> LoadingResult<I, Self::Error>
+	async fn load_with<V>(&mut self, vocabulary: &mut V, url: I) -> LoadingResult<I, Self::Error>
 	where
 		V: IriVocabulary<Iri = I>,
 	{
 		match self.get(&url) {
 			Some(document) => Ok(document.clone()),
-			None => Err(EntryNotFound(url)),
+			None => Err(EntryNotFound(vocabulary.owned_iri(url).ok().unwrap())),
 		}
 	}
 }
 
 impl<I: Clone + Ord> Loader<I> for BTreeMap<I, RemoteDocument<I>> {
-	type Error = EntryNotFound<I>;
+	type Error = EntryNotFound;
 
-	async fn load_with<V>(&mut self, _vocabulary: &mut V, url: I) -> LoadingResult<I, Self::Error>
+	async fn load_with<V>(&mut self, vocabulary: &mut V, url: I) -> LoadingResult<I, Self::Error>
 	where
 		V: IriVocabulary<Iri = I>,
 	{
 		match self.get(&url) {
 			Some(document) => Ok(document.clone()),
-			None => Err(EntryNotFound(url)),
+			None => Err(EntryNotFound(vocabulary.owned_iri(url).ok().unwrap())),
 		}
 	}
 }

--- a/crates/expansion/src/array.rs
+++ b/crates/expansion/src/array.rs
@@ -15,7 +15,7 @@ pub(crate) async fn expand_array<N, L, W>(
 	base_url: Option<&N::Iri>,
 	options: Options,
 	from_map: bool,
-) -> Result<Expanded<N::Iri, N::BlankId>, Error<L::Error>>
+) -> Result<Expanded<N::Iri, N::BlankId>, Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,

--- a/crates/expansion/src/document.rs
+++ b/crates/expansion/src/document.rs
@@ -16,7 +16,7 @@ pub(crate) async fn expand<'a, N, L, W>(
 	active_context: Context<N::Iri, N::BlankId>,
 	base_url: Option<&'a N::Iri>,
 	options: Options,
-) -> Result<ExpandedDocument<N::Iri, N::BlankId>, Error<L::Error>>
+) -> Result<ExpandedDocument<N::Iri, N::BlankId>, Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,

--- a/crates/expansion/src/element.rs
+++ b/crates/expansion/src/element.rs
@@ -62,8 +62,7 @@ impl<'a> PartialEq<Keyword> for ActiveProperty<'a> {
 }
 
 /// Result of the expansion of a single element in a JSON-LD document.
-pub(crate) type ElementExpansionResult<T, B, L> =
-	Result<Expanded<T, B>, Error<<L as Loader<T>>::Error>>;
+pub(crate) type ElementExpansionResult<T, B> = Result<Expanded<T, B>, Error>;
 
 /// Expand an element.
 ///
@@ -78,7 +77,7 @@ pub(crate) async fn expand_element<'a, N, L, W>(
 	base_url: Option<&'a N::Iri>,
 	options: Options,
 	from_map: bool,
-) -> ElementExpansionResult<N::Iri, N::BlankId, L>
+) -> ElementExpansionResult<N::Iri, N::BlankId>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,

--- a/crates/expansion/src/error.rs
+++ b/crates/expansion/src/error.rs
@@ -1,12 +1,12 @@
 use json_ld_syntax::ErrorCode;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error<E> {
+pub enum Error {
 	#[error("Invalid context: {0}")]
 	ContextSyntax(#[from] json_ld_syntax::context::InvalidContext),
 
 	#[error("Context processing failed: {0}")]
-	ContextProcessing(json_ld_context_processing::Error<E>),
+	ContextProcessing(json_ld_context_processing::Error),
 
 	#[error("Invalid `@index` value")]
 	InvalidIndexValue,
@@ -54,7 +54,7 @@ pub enum Error<E> {
 	Value(crate::InvalidValue),
 }
 
-impl<E> Error<E> {
+impl Error {
 	pub fn code(&self) -> ErrorCode {
 		match self {
 			Self::ContextSyntax(e) => e.code(),
@@ -78,7 +78,7 @@ impl<E> Error<E> {
 	}
 }
 
-impl<E> Error<E> {
+impl Error {
 	pub fn duplicate_key_ref(
 		json_syntax::object::Duplicate(a, _b): json_syntax::object::Duplicate<
 			&json_syntax::object::Entry,
@@ -88,19 +88,19 @@ impl<E> Error<E> {
 	}
 }
 
-impl<E> From<json_ld_context_processing::Error<E>> for Error<E> {
-	fn from(e: json_ld_context_processing::Error<E>) -> Self {
+impl From<json_ld_context_processing::Error> for Error {
+	fn from(e: json_ld_context_processing::Error) -> Self {
 		Self::ContextProcessing(e)
 	}
 }
 
-impl<E> From<crate::LiteralExpansionError> for Error<E> {
+impl From<crate::LiteralExpansionError> for Error {
 	fn from(e: crate::LiteralExpansionError) -> Self {
 		Self::Literal(e)
 	}
 }
 
-impl<E> From<crate::InvalidValue> for Error<E> {
+impl From<crate::InvalidValue> for Error {
 	fn from(e: crate::InvalidValue) -> Self {
 		Self::Value(e)
 	}

--- a/crates/expansion/src/lib.rs
+++ b/crates/expansion/src/lib.rs
@@ -36,7 +36,7 @@ pub(crate) use node::*;
 pub(crate) use value::*;
 
 /// Result of the document expansion.
-pub type ExpansionResult<T, B, L> = Result<ExpandedDocument<T, B>, Error<<L as Loader<T>>::Error>>;
+pub type ExpansionResult<T, B> = Result<ExpandedDocument<T, B>, Error>;
 
 /// Handler for the possible warnings emitted during the expansion
 /// of a JSON-LD document.
@@ -123,7 +123,7 @@ pub trait Expand<Iri> {
 		loader: &'a mut L,
 		options: Options,
 		warnings_handler: W,
-	) -> ExpansionResult<N::Iri, N::BlankId, L>
+	) -> ExpansionResult<N::Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
@@ -143,7 +143,7 @@ pub trait Expand<Iri> {
 		&'a self,
 		vocabulary: &'a mut N,
 		loader: &'a mut L,
-	) -> ExpansionResult<Iri, N::BlankId, L>
+	) -> ExpansionResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
@@ -168,7 +168,7 @@ pub trait Expand<Iri> {
 	/// The expansion algorithm is called with an empty initial context with
 	/// a base URL given by [`Expand::default_base_url`].
 	#[allow(async_fn_in_trait)]
-	async fn expand<'a, L>(&'a self, loader: &'a mut L) -> ExpansionResult<Iri, BlankIdBuf, L>
+	async fn expand<'a, L>(&'a self, loader: &'a mut L) -> ExpansionResult<Iri, BlankIdBuf>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
@@ -193,7 +193,7 @@ impl<Iri> Expand<Iri> for Value {
 		loader: &'a mut L,
 		options: Options,
 		mut warnings_handler: W,
-	) -> ExpansionResult<Iri, N::BlankId, L>
+	) -> ExpansionResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
@@ -233,7 +233,7 @@ impl<Iri> Expand<Iri> for RemoteDocument<Iri> {
 		loader: &'a mut L,
 		options: Options,
 		warnings_handler: W,
-	) -> ExpansionResult<Iri, N::BlankId, L>
+	) -> ExpansionResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,

--- a/crates/expansion/src/node.rs
+++ b/crates/expansion/src/node.rs
@@ -35,7 +35,7 @@ pub(crate) async fn expand_node<'a, N, L, W>(
 	expanded_entries: Vec<ExpandedEntry<'a, N::Iri, N::BlankId>>,
 	base_url: Option<&'a N::Iri>,
 	options: Options,
-) -> Result<Option<Indexed<Node<N::Iri, N::BlankId>>>, Error<L::Error>>
+) -> Result<Option<Indexed<Node<N::Iri, N::BlankId>>>, Error>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,
@@ -100,8 +100,7 @@ where
 type ExpandedNode<T, B> = (Indexed<Node<T, B>>, bool);
 
 /// Result of the `expand_node_entries` function.
-type NodeEntriesExpensionResult<T, B, L> =
-	Result<ExpandedNode<T, B>, Error<<L as Loader<T>>::Error>>;
+type NodeEntriesExpensionResult<T, B> = Result<ExpandedNode<T, B>, Error>;
 
 #[allow(clippy::too_many_arguments)]
 async fn expand_node_entries<'a, N, L, W>(
@@ -114,7 +113,7 @@ async fn expand_node_entries<'a, N, L, W>(
 	expanded_entries: Vec<ExpandedEntry<'a, N::Iri, N::BlankId>>,
 	base_url: Option<&'a N::Iri>,
 	options: Options,
-) -> NodeEntriesExpensionResult<N::Iri, N::BlankId, L>
+) -> NodeEntriesExpensionResult<N::Iri, N::BlankId>
 where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,

--- a/crates/syntax/src/lang.rs
+++ b/crates/syntax/src/lang.rs
@@ -12,7 +12,7 @@ pub struct LenientLangTag(str);
 impl LenientLangTag {
 	pub fn new(s: &str) -> (&Self, Option<InvalidLangTag<&str>>) {
 		let err = LangTag::new(s).err();
-		(unsafe { std::mem::transmute(s) }, err)
+		(unsafe { std::mem::transmute::<&str, &Self>(s) }, err)
 	}
 
 	pub fn as_bytes(&self) -> &[u8] {

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -480,7 +480,7 @@ fn parse_enum_type(
 enum Error {
 	Parse(syn::Error),
 	Load(json_ld::loader::fs::Error),
-	Expand(json_ld::expansion::Error<json_ld::fs::Error>),
+	Expand(json_ld::expansion::Error),
 	InvalidIri(String),
 	InvalidValue(
 		Type,

--- a/src/processor/remote_document.rs
+++ b/src/processor/remote_document.rs
@@ -19,7 +19,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		loader: &'a mut L,
 		options: Options<I>,
 		mut warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> CompareResult<I, L>
+	) -> CompareResult
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
@@ -49,7 +49,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		loader: &'a mut L,
 		mut options: Options<I>,
 		mut warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> ExpandResult<I, N::BlankId, L>
+	) -> ExpandResult<I, N::BlankId>
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
@@ -115,7 +115,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		loader: &'a mut L,
 		options: Options<I>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> IntoDocumentResult<I, N::BlankId, L>
+	) -> IntoDocumentResult<I, N::BlankId>
 	where
 		N: VocabularyMut<Iri = I>,
 		I: 'a + Clone + Eq + Hash,
@@ -134,7 +134,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		loader: &'a mut L,
 		options: Options<I>,
 		mut warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> CompactResult<I, L>
+	) -> CompactResult
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
@@ -171,7 +171,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		loader: &'a mut L,
 		options: Options<I>,
 		mut warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> FlattenResult<I, N::BlankId, L>
+	) -> FlattenResult<I, N::BlankId>
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
@@ -219,7 +219,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		loader: &'a mut L,
 		options: Options<I>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> CompareResult<I, L>
+	) -> CompareResult
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
@@ -229,11 +229,11 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		let a = self
 			.loaded_with(vocabulary, loader)
 			.await
-			.map_err(ExpandError::Loading)?;
+			.map_err(ExpandError::from_loader_error)?;
 		let b = other
 			.loaded_with(vocabulary, loader)
 			.await
-			.map_err(ExpandError::Loading)?;
+			.map_err(ExpandError::from_loader_error)?;
 		JsonLdProcessor::compare_full(
 			a.as_ref(),
 			b.as_ref(),
@@ -251,7 +251,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		loader: &'a mut L,
 		options: Options<I>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> ExpandResult<I, N::BlankId, L>
+	) -> ExpandResult<I, N::BlankId>
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
@@ -261,7 +261,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		let doc = self
 			.loaded_with(vocabulary, loader)
 			.await
-			.map_err(ExpandError::Loading)?;
+			.map_err(ExpandError::from_loader_error)?;
 		JsonLdProcessor::expand_full(doc.as_ref(), vocabulary, loader, options, warnings).await
 	}
 
@@ -271,7 +271,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		loader: &'a mut L,
 		options: Options<I>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> IntoDocumentResult<I, N::BlankId, L>
+	) -> IntoDocumentResult<I, N::BlankId>
 	where
 		N: VocabularyMut<Iri = I>,
 		I: 'a + Clone + Eq + Hash,
@@ -281,7 +281,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		let doc = self
 			.load_with(vocabulary, loader)
 			.await
-			.map_err(ExpandError::Loading)?;
+			.map_err(ExpandError::from_loader_error)?;
 		JsonLdProcessor::into_document_full(doc, vocabulary, loader, options, warnings).await
 	}
 
@@ -292,7 +292,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		loader: &'a mut L,
 		options: Options<I>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> CompactResult<I, L>
+	) -> CompactResult
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
@@ -302,7 +302,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		let doc = self
 			.loaded_with(vocabulary, loader)
 			.await
-			.map_err(CompactError::Loading)?;
+			.map_err(CompactError::from_loader_error)?;
 		JsonLdProcessor::compact_full(doc.as_ref(), vocabulary, context, loader, options, warnings)
 			.await
 	}
@@ -315,7 +315,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		loader: &'a mut L,
 		options: Options<I>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
-	) -> FlattenResult<I, N::BlankId, L>
+	) -> FlattenResult<I, N::BlankId>
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
@@ -325,7 +325,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		let doc = self
 			.loaded_with(vocabulary, loader)
 			.await
-			.map_err(FlattenError::Loading)?;
+			.map_err(FlattenError::from_loader_error)?;
 		JsonLdProcessor::flatten_full(
 			doc.as_ref(),
 			vocabulary,

--- a/tests/custom.rs
+++ b/tests/custom.rs
@@ -44,7 +44,7 @@ async fn custom_01() {
 #[test]
 fn custom_01_high_memory() {
 	let child = std::thread::Builder::new()
-		.stack_size(2 * 512 * 1024)
+		.stack_size(3 * 512 * 1024)
 		.spawn(|| async_std::task::block_on(custom_01()))
 		.unwrap();
 


### PR DESCRIPTION
Most of the error types in `json-ld` currently needs to be provided with the loader error type as generic parameter. Dealing with generic type parameters on error types is really annoying, as it propagates everywhere. This PR fixes this erasing the loader error type using a `LoaderError` trait allowing the different algorithm to transform a loader error into an IRI (causing the error) and an error message. I believe this will be enough in the majority of cases to give enough info about the error while reducing the burden propagating type generics.

This decision was made while fixing the `FsLoader` to allow multiples IRIs bound to the same path, to allow easy debugging. For this reason this PR also includes a fix for the `FsLoader`.