### PR TITLE
Better generics defaults & useful re-exports.

### DIFF
--- a/crates/core/src/context/definition.rs
+++ b/crates/core/src/context/definition.rs
@@ -1,6 +1,7 @@
 use super::{IntoSyntax, Nest};
 use crate::{Container, Direction, LenientLangTagBuf, Nullable, Term, Type};
 use contextual::WithContext;
+use iref::IriBuf;
 use json_ld_syntax::{
 	context::{
 		definition::{Key, TypeContainer},
@@ -8,13 +9,13 @@ use json_ld_syntax::{
 	},
 	KeywordType,
 };
-use rdf_types::{vocabulary::IriVocabulary, Id, Vocabulary};
+use rdf_types::{vocabulary::IriVocabulary, BlankIdBuf, Id, Vocabulary};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::{borrow::Borrow, fmt};
 
 /// Term binding.
-pub enum Binding<T, B> {
+pub enum Binding<T = IriBuf, B = BlankIdBuf> {
 	/// Normal term definition.
 	Normal(Key, NormalTermDefinition<T, B>),
 
@@ -416,7 +417,7 @@ impl<T, B> TermDefinition<T, B> {
 
 /// Term definition reference.
 #[derive(PartialEq, Eq)]
-pub enum TermDefinitionRef<'a, T, B> {
+pub enum TermDefinitionRef<'a, T = IriBuf, B = BlankIdBuf> {
 	/// `@type` definition.
 	Type(&'a TypeTermDefinition),
 
@@ -524,7 +525,7 @@ impl<'a, T, B> Copy for TermDefinitionRef<'a, T, B> {}
 
 // A term definition.
 #[derive(PartialEq, Eq, Clone)]
-pub struct NormalTermDefinition<T, B> {
+pub struct NormalTermDefinition<T = IriBuf, B = BlankIdBuf> {
 	// IRI mapping.
 	pub value: Option<Term<T, B>>,
 

--- a/crates/core/src/context/inverse.rs
+++ b/crates/core/src/context/inverse.rs
@@ -1,3 +1,5 @@
+use iref::IriBuf;
+
 use super::BindingRef;
 use super::Context;
 use super::Key;
@@ -8,7 +10,7 @@ use std::fmt;
 use std::hash::Hash;
 
 #[derive(Clone, PartialEq, Eq)]
-pub enum TypeSelection<T> {
+pub enum TypeSelection<T = IriBuf> {
 	Reverse,
 	Any,
 	Type(Type<T>),

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -4,9 +4,10 @@ pub mod inverse;
 
 use crate::{Direction, LenientLangTag, LenientLangTagBuf, Term};
 use contextual::WithContext;
+use iref::IriBuf;
 use json_ld_syntax::{KeywordType, Nullable};
 use once_cell::sync::OnceCell;
-use rdf_types::{Id, Vocabulary};
+use rdf_types::{BlankIdBuf, Id, Vocabulary};
 use std::borrow::Borrow;
 use std::hash::Hash;
 
@@ -25,7 +26,7 @@ pub use inverse::InverseContext;
 ///
 /// [1]: <https://www.w3.org/TR/json-ld11-api/#context-processing-algorithm>
 /// [`json-ld-context-processing`]: <https://crates.io/crates/json-ld-context-processing>
-pub struct Context<T, B> {
+pub struct Context<T = IriBuf, B = BlankIdBuf> {
 	original_base_url: Option<T>,
 	base_iri: Option<T>,
 	vocabulary: Option<Term<T, B>>,
@@ -51,7 +52,7 @@ impl<T, B> Default for Context<T, B> {
 	}
 }
 
-pub type DefinitionEntryRef<'a, T, B> = (&'a Key, &'a TermDefinition<T, B>);
+pub type DefinitionEntryRef<'a, T = IriBuf, B = BlankIdBuf> = (&'a Key, &'a TermDefinition<T, B>);
 
 impl<T, B> Context<T, B> {
 	/// Create a new context with the given base IRI.
@@ -282,7 +283,7 @@ impl<T, B> Context<T, B> {
 }
 
 /// Context fragment to syntax method.
-pub trait IntoSyntax<T, B> {
+pub trait IntoSyntax<T = IriBuf, B = BlankIdBuf> {
 	fn into_syntax(
 		self,
 		vocabulary: &impl Vocabulary<Iri = T, BlankId = B>,

--- a/crates/core/src/loader/fs.rs
+++ b/crates/core/src/loader/fs.rs
@@ -2,7 +2,7 @@ use super::{Loader, RemoteDocument};
 use crate::{LoaderError, LoadingResult};
 use iref::IriBuf;
 use json_syntax::Parse;
-use rdf_types::vocabulary::{IriIndex, IriVocabulary};
+use rdf_types::vocabulary::IriVocabulary;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -40,7 +40,7 @@ impl LoaderError for Error {
 ///
 /// Loaded documents are not cached: a new file system read is made each time
 /// an URL is loaded even if it has already been queried before.
-pub struct FsLoader<I = IriIndex> {
+pub struct FsLoader<I = IriBuf> {
 	mount_points: Vec<(PathBuf, I)>,
 }
 

--- a/crates/core/src/term.rs
+++ b/crates/core/src/term.rs
@@ -1,12 +1,13 @@
 use crate::{Id, ValidId};
 use contextual::{AsRefWithContext, DisplayWithContext, WithContext};
+use iref::IriBuf;
 use json_ld_syntax::Keyword;
-use rdf_types::vocabulary::Vocabulary;
+use rdf_types::{vocabulary::Vocabulary, BlankIdBuf};
 use std::fmt;
 
 /// Identifier, keyword or `@null`.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub enum Term<T, B> {
+pub enum Term<T = IriBuf, B = BlankIdBuf> {
 	/// `@null` value.
 	Null,
 

--- a/crates/core/src/ty.rs
+++ b/crates/core/src/ty.rs
@@ -1,5 +1,6 @@
 use super::Term;
 use crate::{Id, ValidId};
+use iref::IriBuf;
 use json_ld_syntax::Keyword;
 use std::convert::TryFrom;
 use std::fmt;
@@ -8,7 +9,7 @@ use std::fmt;
 ///
 /// This is the value of a `@type` entry.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub enum Type<I> {
+pub enum Type<I = IriBuf> {
 	/// `@id`.
 	///
 	/// The value must be interpreted as an IRI.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,3 +315,10 @@ pub use expansion::Expand;
 
 mod processor;
 pub use processor::*;
+
+#[doc(hidden)]
+pub use iref;
+pub use iref::{InvalidIri, Iri, IriBuf, IriRef, IriRefBuf};
+
+pub use rdf_types;
+pub use rdf_types::{BlankId, BlankIdBuf};

--- a/tests/compact.rs
+++ b/tests/compact.rs
@@ -97,7 +97,7 @@ impl compact::Test {
 		}
 
 		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
-		let mut loader: json_ld::FsLoader = json_ld::FsLoader::default();
+		let mut loader: json_ld::FsLoader<IriIndex> = json_ld::FsLoader::default();
 		loader.mount(
 			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api")),
 			"tests/json-ld-api",

--- a/tests/expand.rs
+++ b/tests/expand.rs
@@ -87,7 +87,7 @@ impl expand::Test {
 		}
 
 		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
-		let mut loader: json_ld::FsLoader = json_ld::FsLoader::default();
+		let mut loader: json_ld::FsLoader<IriIndex> = json_ld::FsLoader::default();
 		loader.mount(
 			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api")),
 			"tests/json-ld-api",

--- a/tests/flatten.rs
+++ b/tests/flatten.rs
@@ -96,7 +96,7 @@ impl flatten::Test {
 		}
 
 		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
-		let mut loader: json_ld::FsLoader = json_ld::FsLoader::default();
+		let mut loader: json_ld::FsLoader<IriIndex> = json_ld::FsLoader::default();
 		loader.mount(
 			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api")),
 			"tests/json-ld-api",

--- a/tests/to_rdf.rs
+++ b/tests/to_rdf.rs
@@ -110,7 +110,7 @@ impl to_rdf::Test {
 		}
 
 		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
-		let mut loader: json_ld::FsLoader = json_ld::FsLoader::default();
+		let mut loader: json_ld::FsLoader<IriIndex> = json_ld::FsLoader::default();
 		loader.mount(
 			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api")),
 			"tests/json-ld-api",


### PR DESCRIPTION
Add generics default to `Context` type, change default IRI type of `FsLoader` to `IriBuf` and re-export `iref` and `rdf-types`.