### PR TITLE
Const loader without generics.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -84,8 +84,7 @@ async fn main() {
 
 	let mut vocabulary: rdf_types::vocabulary::IndexVocabulary =
 		rdf_types::vocabulary::IndexVocabulary::new();
-	let mut loader: json_ld::loader::ReqwestLoader<IriIndex> =
-		json_ld::loader::ReqwestLoader::new();
+	let mut loader: json_ld::loader::ReqwestLoader = json_ld::loader::ReqwestLoader::new();
 
 	match args.command {
 		Command::Fetch { url } => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -84,13 +84,13 @@ async fn main() {
 
 	let mut vocabulary: rdf_types::vocabulary::IndexVocabulary =
 		rdf_types::vocabulary::IndexVocabulary::new();
-	let mut loader: json_ld::loader::ReqwestLoader = json_ld::loader::ReqwestLoader::new();
+	let loader = json_ld::loader::ReqwestLoader::new();
 
 	match args.command {
 		Command::Fetch { url } => {
 			let url = vocabulary.insert(url.as_iri());
 			match RemoteDocumentReference::iri(url)
-				.load_with(&mut vocabulary, &mut loader)
+				.load_with(&mut vocabulary, &loader)
 				.await
 			{
 				Ok(remote_document) => {
@@ -121,7 +121,7 @@ async fn main() {
 			};
 
 			match remote_document
-				.expand_with_using(&mut vocabulary, &mut loader, options)
+				.expand_with_using(&mut vocabulary, &loader, options)
 				.await
 			{
 				Ok(mut expanded) => {
@@ -155,7 +155,7 @@ async fn main() {
 			let mut generator = rdf_types::generator::Blank::new_with_prefix("b".to_string());
 
 			match remote_document
-				.flatten_with(&mut vocabulary, &mut generator, &mut loader)
+				.flatten_with(&mut vocabulary, &mut generator, &loader)
 				.await
 			{
 				Ok(flattened) => {

--- a/crates/compaction/src/document.rs
+++ b/crates/compaction/src/document.rs
@@ -38,7 +38,7 @@ pub trait Compact<I, B> {
 		&'a self,
 		vocabulary: &'a mut N,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: crate::Options,
 	) -> CompactDocumentResult
 	where
@@ -54,7 +54,7 @@ pub trait Compact<I, B> {
 		&'a self,
 		vocabulary: &'a mut N,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
-		loader: &'a mut L,
+		loader: &'a L,
 	) -> CompactDocumentResult
 	where
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
@@ -71,7 +71,7 @@ pub trait Compact<I, B> {
 	async fn compact<'a, L>(
 		&'a self,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
-		loader: &'a mut L,
+		loader: &'a L,
 	) -> CompactDocumentResult
 	where
 		(): rdf_types::VocabularyMut<Iri = I, BlankId = B>,
@@ -89,7 +89,7 @@ impl<I, B> Compact<I, B> for ExpandedDocument<I, B> {
 		&'a self,
 		vocabulary: &'a mut N,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: crate::Options,
 	) -> CompactDocumentResult
 	where
@@ -121,7 +121,7 @@ impl<I, B> Compact<I, B> for FlattenedDocument<I, B> {
 		&'a self,
 		vocabulary: &'a mut N,
 		context: json_ld_context_processing::ProcessedRef<'a, 'a, I, B>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: crate::Options,
 	) -> CompactDocumentResult
 	where

--- a/crates/compaction/src/document.rs
+++ b/crates/compaction/src/document.rs
@@ -45,7 +45,7 @@ pub trait Compact<I, B> {
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>;
+		L: Loader;
 
 	/// Compacts the input document with the given `vocabulary` to
 	/// interpret identifiers.
@@ -60,7 +60,7 @@ pub trait Compact<I, B> {
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		self.compact_full(vocabulary, context, loader, crate::Options::default())
 			.await
@@ -77,7 +77,7 @@ pub trait Compact<I, B> {
 		(): rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		self.compact_with(vocabulary::no_vocabulary_mut(), context, loader)
 			.await
@@ -96,7 +96,7 @@ impl<I, B> Compact<I, B> for ExpandedDocument<I, B> {
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let mut compacted_output = self
 			.objects()
@@ -128,7 +128,7 @@ impl<I, B> Compact<I, B> for FlattenedDocument<I, B> {
 		N: rdf_types::VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let mut compacted_output = self
 			.compact_fragment_full(

--- a/crates/compaction/src/lib.rs
+++ b/crates/compaction/src/lib.rs
@@ -137,7 +137,7 @@ pub trait CompactFragment<I, B> {
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>;
+		L: Loader;
 
 	#[allow(async_fn_in_trait)]
 	#[inline(always)]
@@ -151,7 +151,7 @@ pub trait CompactFragment<I, B> {
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		self.compact_fragment_full(
 			vocabulary,
@@ -175,7 +175,7 @@ pub trait CompactFragment<I, B> {
 		(): VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		self.compact_fragment_full(
 			vocabulary::no_vocabulary_mut(),
@@ -212,7 +212,7 @@ pub trait CompactIndexedFragment<I, B> {
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>;
+		L: Loader;
 }
 
 impl<I, B, T: CompactIndexedFragment<I, B>> CompactFragment<I, B> for Indexed<T> {
@@ -229,7 +229,7 @@ impl<I, B, T: CompactIndexedFragment<I, B>> CompactFragment<I, B> for Indexed<T>
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		self.inner()
 			.compact_indexed_fragment(
@@ -260,7 +260,7 @@ impl<I, B, T: Any<I, B>> CompactIndexedFragment<I, B> for T {
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		use json_ld_core::object::Ref;
 		match self.as_ref() {
@@ -461,7 +461,7 @@ where
 	N::BlankId: Clone + Hash + Eq,
 	T: 'a + CompactFragment<N::Iri, N::BlankId>,
 	O: 'a + Iterator<Item = &'a T>,
-	L: Loader<N::Iri>,
+	L: Loader,
 {
 	let mut result = Vec::new();
 
@@ -520,7 +520,7 @@ impl<T: CompactFragment<I, B>, I, B> CompactFragment<I, B> for IndexSet<T> {
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		compact_collection_with(
 			vocabulary,
@@ -549,7 +549,7 @@ impl<T: CompactFragment<I, B>, I, B> CompactFragment<I, B> for Vec<T> {
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		compact_collection_with(
 			vocabulary,
@@ -578,7 +578,7 @@ impl<T: CompactFragment<I, B> + Send + Sync, I, B> CompactFragment<I, B> for [T]
 		N: VocabularyMut<Iri = I, BlankId = B>,
 		I: Clone + Hash + Eq,
 		B: Clone + Hash + Eq,
-		L: Loader<I>,
+		L: Loader,
 	{
 		compact_collection_with(
 			vocabulary,

--- a/crates/compaction/src/lib.rs
+++ b/crates/compaction/src/lib.rs
@@ -130,7 +130,7 @@ pub trait CompactFragment<I, B> {
 		active_context: &'a Context<I, B>,
 		type_scoped_context: &'a Context<I, B>,
 		active_property: Option<&'a str>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 	) -> CompactFragmentResult
 	where
@@ -205,7 +205,7 @@ pub trait CompactIndexedFragment<I, B> {
 		active_context: &'a Context<I, B>,
 		type_scoped_context: &'a Context<I, B>,
 		active_property: Option<&'a str>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 	) -> CompactFragmentResult
 	where
@@ -222,7 +222,7 @@ impl<I, B, T: CompactIndexedFragment<I, B>> CompactFragment<I, B> for Indexed<T>
 		active_context: &'a Context<I, B>,
 		type_scoped_context: &'a Context<I, B>,
 		active_property: Option<&'a str>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 	) -> CompactFragmentResult
 	where
@@ -253,7 +253,7 @@ impl<I, B, T: Any<I, B>> CompactIndexedFragment<I, B> for T {
 		active_context: &'a Context<I, B>,
 		type_scoped_context: &'a Context<I, B>,
 		active_property: Option<&'a str>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 	) -> CompactFragmentResult
 	where
@@ -452,7 +452,7 @@ async fn compact_collection_with<'a, N, L, O, T>(
 	active_context: &'a Context<N::Iri, N::BlankId>,
 	type_scoped_context: &'a Context<N::Iri, N::BlankId>,
 	active_property: Option<&'a str>,
-	loader: &'a mut L,
+	loader: &'a L,
 	options: Options,
 ) -> CompactFragmentResult
 where
@@ -513,7 +513,7 @@ impl<T: CompactFragment<I, B>, I, B> CompactFragment<I, B> for IndexSet<T> {
 		active_context: &'a Context<I, B>,
 		type_scoped_context: &'a Context<I, B>,
 		active_property: Option<&'a str>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 	) -> CompactFragmentResult
 	where
@@ -542,7 +542,7 @@ impl<T: CompactFragment<I, B>, I, B> CompactFragment<I, B> for Vec<T> {
 		active_context: &'a Context<I, B>,
 		type_scoped_context: &'a Context<I, B>,
 		active_property: Option<&'a str>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 	) -> CompactFragmentResult
 	where
@@ -571,7 +571,7 @@ impl<T: CompactFragment<I, B> + Send + Sync, I, B> CompactFragment<I, B> for [T]
 		active_context: &'a Context<I, B>,
 		type_scoped_context: &'a Context<I, B>,
 		active_property: Option<&'a str>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 	) -> CompactFragmentResult
 	where

--- a/crates/compaction/src/node.rs
+++ b/crates/compaction/src/node.rs
@@ -21,7 +21,7 @@ pub async fn compact_indexed_node_with<N, L>(
 	mut active_context: &Context<N::Iri, N::BlankId>,
 	type_scoped_context: &Context<N::Iri, N::BlankId>,
 	active_property: Option<&str>,
-	loader: &mut L,
+	loader: &L,
 	options: Options,
 ) -> Result<json_syntax::Value, Error>
 where

--- a/crates/compaction/src/node.rs
+++ b/crates/compaction/src/node.rs
@@ -28,7 +28,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,
 	N::BlankId: Clone + Hash + Eq,
-	L: Loader<N::Iri>,
+	L: Loader,
 {
 	// If active context has a previous context, the active context is not propagated.
 	// If element does not contain an @value entry, and element does not consist of

--- a/crates/compaction/src/property.rs
+++ b/crates/compaction/src/property.rs
@@ -22,7 +22,7 @@ async fn compact_property_list<N, L>(
 	as_array: bool,
 	item_active_property: &str,
 	active_context: &Context<N::Iri, N::BlankId>,
-	loader: &mut L,
+	loader: &L,
 	options: Options,
 ) -> Result<(), Error>
 where
@@ -107,7 +107,7 @@ async fn compact_property_graph<N, L>(
 	as_array: bool,
 	item_active_property: &str,
 	active_context: &Context<N::Iri, N::BlankId>,
-	loader: &mut L,
+	loader: &L,
 	options: Options,
 ) -> Result<(), Error>
 where
@@ -389,7 +389,7 @@ pub async fn compact_property<'a, N, L, O, T>(
 	expanded_property: Term<N::Iri, N::BlankId>,
 	expanded_value: O,
 	active_context: &Context<N::Iri, N::BlankId>,
-	loader: &mut L,
+	loader: &L,
 	inside_reverse: bool,
 	options: Options,
 ) -> Result<(), Error>

--- a/crates/compaction/src/property.rs
+++ b/crates/compaction/src/property.rs
@@ -29,7 +29,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,
 	N::BlankId: Clone + Hash + Eq,
-	L: Loader<N::Iri>,
+	L: Loader,
 {
 	// If expanded item is a list object:
 	let mut compacted_item = Box::pin(compact_collection_with(
@@ -114,7 +114,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,
 	N::BlankId: Clone + Hash + Eq,
-	L: Loader<N::Iri>,
+	L: Loader,
 {
 	// If expanded item is a graph object
 	let mut compacted_item = Box::pin(node.graph().unwrap().compact_fragment_full(
@@ -399,7 +399,7 @@ where
 	N::BlankId: Clone + Hash + Eq,
 	O: IntoIterator<Item = &'a Indexed<T>>,
 	T: 'a + object::Any<N::Iri, N::BlankId>,
-	L: Loader<N::Iri>,
+	L: Loader,
 {
 	let mut is_empty = true;
 

--- a/crates/compaction/src/value.rs
+++ b/crates/compaction/src/value.rs
@@ -13,7 +13,7 @@ pub async fn compact_indexed_value_with<N, L>(
 	index: Option<&str>,
 	active_context: &Context<N::Iri, N::BlankId>,
 	active_property: Option<&str>,
-	loader: &mut L,
+	loader: &L,
 	options: Options,
 ) -> Result<json_syntax::Value, Error>
 where

--- a/crates/compaction/src/value.rs
+++ b/crates/compaction/src/value.rs
@@ -20,7 +20,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Hash + Eq,
 	N::BlankId: Clone + Hash + Eq,
-	L: Loader<N::Iri>,
+	L: Loader,
 {
 	// If the term definition for active property in active context has a local context:
 	let mut active_context = Mown::Borrowed(active_context);

--- a/crates/context-processing/src/algorithm/define.rs
+++ b/crates/context-processing/src/algorithm/define.rs
@@ -13,7 +13,7 @@ use json_ld_syntax::{
 	CompactIri, ContainerKind, ExpandableRef, Keyword, LenientLangTag, Nullable,
 };
 use rdf_types::{BlankId, VocabularyMut};
-use std::collections::HashMap;
+use std::{collections::HashMap, hash::Hash};
 
 fn is_gen_delim(c: char) -> bool {
 	matches!(c, ':' | '/' | '?' | '#' | '[' | ']' | '@')
@@ -97,9 +97,9 @@ pub async fn define<'a, N, L, W>(
 ) -> Result<(), Error>
 where
 	N: VocabularyMut,
-	N::Iri: Clone + PartialEq,
+	N::Iri: Clone + Eq + Hash,
 	N::BlankId: Clone + PartialEq,
-	L: Loader<N::Iri>,
+	L: Loader,
 	W: WarningHandler<N>,
 {
 	let term = term.to_owned();

--- a/crates/context-processing/src/algorithm/iri.rs
+++ b/crates/context-processing/src/algorithm/iri.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use super::{DefinedTerms, Environment, Merged};
 use crate::{Error, Options, ProcessingStack, Warning, WarningHandler};
 use contextual::WithContext;
@@ -33,9 +35,9 @@ pub async fn expand_iri_with<'a, N, L, W>(
 ) -> ExpandIriResult<N::Iri, N::BlankId>
 where
 	N: VocabularyMut,
-	N::Iri: Clone + PartialEq,
+	N::Iri: Clone + Eq + Hash,
 	N::BlankId: Clone + PartialEq,
-	L: Loader<N::Iri>,
+	L: Loader,
 	W: WarningHandler<N>,
 {
 	match value {

--- a/crates/context-processing/src/algorithm/mod.rs
+++ b/crates/context-processing/src/algorithm/mod.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use crate::{
 	Error, Options, Process, Processed, ProcessingResult, ProcessingStack, WarningHandler,
 };
@@ -27,9 +29,9 @@ impl Process for syntax::context::Context {
 	) -> Result<Processed<N::Iri, N::BlankId>, Error>
 	where
 		N: VocabularyMut,
-		N::Iri: Clone + PartialEq,
+		N::Iri: Clone + Eq + Hash,
 		N::BlankId: Clone + PartialEq,
-		L: Loader<N::Iri>,
+		L: Loader,
 		W: WarningHandler<N>,
 	{
 		process_context(
@@ -78,9 +80,9 @@ async fn process_context<'l: 'a, 'a, N, L, W>(
 ) -> ProcessingResult<'l, N::Iri, N::BlankId>
 where
 	N: VocabularyMut,
-	N::Iri: Clone + PartialEq,
+	N::Iri: Clone + Eq + Hash,
 	N::BlankId: Clone + PartialEq,
-	L: Loader<N::Iri>,
+	L: Loader,
 	W: WarningHandler<N>,
 {
 	// 1) Initialize result to the result of cloning active context.

--- a/crates/context-processing/src/algorithm/mod.rs
+++ b/crates/context-processing/src/algorithm/mod.rs
@@ -22,7 +22,7 @@ impl Process for syntax::context::Context {
 		&self,
 		vocabulary: &mut N,
 		active_context: &Context<N::Iri, N::BlankId>,
-		loader: &mut L,
+		loader: &L,
 		base_url: Option<N::Iri>,
 		options: Options,
 		mut warnings: W,
@@ -169,8 +169,7 @@ where
 					let loaded_context = env
 						.loader
 						.load_with(env.vocabulary, context_iri.clone())
-						.await
-						.map_err(Error::from_context_loader_error)?
+						.await?
 						.into_document()
 						.into_ld_context()
 						.map_err(Error::ContextExtractionFailed)?;
@@ -235,8 +234,7 @@ where
 						let import_context = env
 							.loader
 							.load_with(env.vocabulary, import.clone())
-							.await
-							.map_err(Error::from_context_loader_error)?
+							.await?
 							.into_document()
 							.into_ld_context()
 							.map_err(Error::ContextExtractionFailed)?;

--- a/crates/context-processing/src/lib.rs
+++ b/crates/context-processing/src/lib.rs
@@ -4,7 +4,7 @@ pub use json_ld_core::{warning, Context, ProcessingMode};
 use json_ld_core::{ExtractContextError, Loader, LoaderError};
 use json_ld_syntax::ErrorCode;
 use rdf_types::VocabularyMut;
-use std::fmt;
+use std::{fmt, hash::Hash};
 
 pub mod algorithm;
 mod processed;
@@ -157,9 +157,9 @@ pub trait Process {
 	) -> Result<Processed<N::Iri, N::BlankId>, Error>
 	where
 		N: VocabularyMut,
-		N::Iri: Clone + PartialEq,
+		N::Iri: Clone + Eq + Hash,
 		N::BlankId: Clone + PartialEq,
-		L: Loader<N::Iri>,
+		L: Loader,
 		W: WarningHandler<N>;
 
 	/// Process the local context with specific options.
@@ -175,9 +175,9 @@ pub trait Process {
 	) -> Result<Processed<N::Iri, N::BlankId>, Error>
 	where
 		N: VocabularyMut,
-		N::Iri: Clone + PartialEq,
+		N::Iri: Clone + Eq + Hash,
 		N::BlankId: Clone + PartialEq,
-		L: Loader<N::Iri>,
+		L: Loader
 	{
 		self.process_full(
 			vocabulary,
@@ -201,9 +201,9 @@ pub trait Process {
 	) -> Result<Processed<N::Iri, N::BlankId>, Error>
 	where
 		N: VocabularyMut,
-		N::Iri: Clone + PartialEq,
+		N::Iri: Clone + Eq + Hash,
 		N::BlankId: Clone + PartialEq,
-		L: Loader<N::Iri>,
+		L: Loader
 	{
 		let active_context = Context::default();
 		self.process_full(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -39,6 +39,6 @@ pub use ty::*;
 
 pub struct Environment<'a, N, L, W> {
 	pub vocabulary: &'a mut N,
-	pub loader: &'a mut L,
+	pub loader: &'a L,
 	pub warnings: &'a mut W,
 }

--- a/crates/core/src/loader/fs.rs
+++ b/crates/core/src/loader/fs.rs
@@ -1,8 +1,7 @@
 use super::{Loader, RemoteDocument};
 use crate::{LoaderError, LoadingResult};
-use iref::IriBuf;
+use iref::{Iri, IriBuf};
 use json_syntax::Parse;
-use rdf_types::vocabulary::IriVocabulary;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -40,25 +39,23 @@ impl LoaderError for Error {
 ///
 /// Loaded documents are not cached: a new file system read is made each time
 /// an URL is loaded even if it has already been queried before.
-pub struct FsLoader<I = IriBuf> {
-	mount_points: Vec<(PathBuf, I)>,
+pub struct FsLoader {
+	mount_points: Vec<(PathBuf, IriBuf)>,
 }
 
-impl<I> FsLoader<I> {
+impl FsLoader {
 	/// Bind the given IRI prefix to the given path.
 	///
 	/// Any document with an IRI matching the given prefix will be loaded from
 	/// the referenced local directory.
 	#[inline(always)]
-	pub fn mount<P: AsRef<Path>>(&mut self, url: I, path: P) {
+	pub fn mount<P: AsRef<Path>>(&mut self, url: IriBuf, path: P) {
 		self.mount_points.push((path.as_ref().into(), url));
 	}
 
 	/// Returns the local file path associated to the given `url` if any.
-	pub fn filepath(&self, vocabulary: &impl IriVocabulary<Iri = I>, url: &I) -> Option<PathBuf> {
-		let url = vocabulary.iri(url).unwrap();
+	pub fn filepath(&self, url: &Iri) -> Option<PathBuf> {
 		for (path, target_url) in &self.mount_points {
-			let target_url = vocabulary.iri(target_url).unwrap().as_iri_ref();
 			if let Some((suffix, _, _)) = url.as_iri_ref().suffix(target_url) {
 				let mut filepath = path.clone();
 				for seg in suffix.as_path().segments() {
@@ -73,36 +70,33 @@ impl<I> FsLoader<I> {
 	}
 }
 
-impl<I> Loader<I> for FsLoader<I> {
+impl Loader for FsLoader {
 	type Error = Error;
 
-	async fn load_with<V>(&mut self, vocabulary: &mut V, url: I) -> LoadingResult<I, Error>
-	where
-		V: IriVocabulary<Iri = I>,
-	{
-		match self.filepath(vocabulary, &url) {
+	async fn load(&mut self, url: &Iri) -> LoadingResult<IriBuf, Error> {
+		match self.filepath(url) {
 			Some(filepath) => {
 				let file = File::open(filepath)
-					.map_err(|e| Error::IO(vocabulary.iri(&url).unwrap().to_owned(), e))?;
+					.map_err(|e| Error::IO(url.to_owned(), e))?;
 				let mut buf_reader = BufReader::new(file);
 				let mut contents = String::new();
 				buf_reader
 					.read_to_string(&mut contents)
-					.map_err(|e| Error::IO(vocabulary.iri(&url).unwrap().to_owned(), e))?;
+					.map_err(|e| Error::IO(url.to_owned(), e))?;
 				let (doc, _) = json_syntax::Value::parse_str(&contents)
-					.map_err(|e| Error::Parse(vocabulary.iri(&url).unwrap().to_owned(), e))?;
+					.map_err(|e| Error::Parse(url.to_owned(), e))?;
 				Ok(RemoteDocument::new(
-					Some(url),
+					Some(url.to_owned()),
 					Some("application/ld+json".parse().unwrap()),
 					doc,
 				))
 			}
-			None => Err(Error::NoMountPoint(vocabulary.owned_iri(url).ok().unwrap())),
+			None => Err(Error::NoMountPoint(url.to_owned())),
 		}
 	}
 }
 
-impl<I> Default for FsLoader<I> {
+impl Default for FsLoader {
 	fn default() -> Self {
 		Self {
 			mount_points: Vec::new(),
@@ -110,7 +104,7 @@ impl<I> Default for FsLoader<I> {
 	}
 }
 
-impl<I> FsLoader<I> {
+impl FsLoader {
 	/// Creates a new file system loader with the given content `parser`.
 	pub fn new() -> Self {
 		Self::default()

--- a/crates/core/src/loader/map.rs
+++ b/crates/core/src/loader/map.rs
@@ -1,9 +1,7 @@
 use super::{Loader, RemoteDocument};
 use crate::{LoaderError, LoadingResult};
-use iref::IriBuf;
-use rdf_types::vocabulary::IriVocabulary;
+use iref::{Iri, IriBuf};
 use std::collections::{BTreeMap, HashMap};
-use std::hash::Hash;
 
 /// Error returned using [`HashMap`] or [`BTreeMap`] as a [`Loader`] with the
 /// requested document is not found.
@@ -17,30 +15,24 @@ impl LoaderError for EntryNotFound {
 	}
 }
 
-impl<I: Clone + Eq + Hash> Loader<I> for HashMap<I, RemoteDocument<I>> {
+impl Loader for HashMap<IriBuf, RemoteDocument> {
 	type Error = EntryNotFound;
 
-	async fn load_with<V>(&mut self, vocabulary: &mut V, url: I) -> LoadingResult<I, Self::Error>
-	where
-		V: IriVocabulary<Iri = I>,
-	{
-		match self.get(&url) {
+	async fn load(&mut self, url: &Iri) -> LoadingResult<IriBuf, Self::Error> {
+		match self.get(url) {
 			Some(document) => Ok(document.clone()),
-			None => Err(EntryNotFound(vocabulary.owned_iri(url).ok().unwrap())),
+			None => Err(EntryNotFound(url.to_owned())),
 		}
 	}
 }
 
-impl<I: Clone + Ord> Loader<I> for BTreeMap<I, RemoteDocument<I>> {
+impl Loader for BTreeMap<IriBuf, RemoteDocument> {
 	type Error = EntryNotFound;
 
-	async fn load_with<V>(&mut self, vocabulary: &mut V, url: I) -> LoadingResult<I, Self::Error>
-	where
-		V: IriVocabulary<Iri = I>,
-	{
-		match self.get(&url) {
+	async fn load(&mut self, url: &Iri) -> LoadingResult<IriBuf, Self::Error> {
+		match self.get(url) {
 			Some(document) => Ok(document.clone()),
-			None => Err(EntryNotFound(vocabulary.owned_iri(url).ok().unwrap())),
+			None => Err(EntryNotFound(url.to_owned())),
 		}
 	}
 }

--- a/crates/core/src/loader/map.rs
+++ b/crates/core/src/loader/map.rs
@@ -1,38 +1,28 @@
 use super::{Loader, RemoteDocument};
-use crate::{LoaderError, LoadingResult};
+use crate::{LoadError, LoadingResult};
 use iref::{Iri, IriBuf};
 use std::collections::{BTreeMap, HashMap};
 
 /// Error returned using [`HashMap`] or [`BTreeMap`] as a [`Loader`] with the
 /// requested document is not found.
 #[derive(Debug, thiserror::Error)]
-#[error("document `{0}` not found")]
-pub struct EntryNotFound(pub IriBuf);
-
-impl LoaderError for EntryNotFound {
-	fn into_iri_and_message(self) -> (IriBuf, String) {
-		(self.0, "not found".to_string())
-	}
-}
+#[error("document not found")]
+pub struct EntryNotFound;
 
 impl Loader for HashMap<IriBuf, RemoteDocument> {
-	type Error = EntryNotFound;
-
-	async fn load(&mut self, url: &Iri) -> LoadingResult<IriBuf, Self::Error> {
+	async fn load(&self, url: &Iri) -> LoadingResult<IriBuf> {
 		match self.get(url) {
 			Some(document) => Ok(document.clone()),
-			None => Err(EntryNotFound(url.to_owned())),
+			None => Err(LoadError::new(url.to_owned(), EntryNotFound)),
 		}
 	}
 }
 
 impl Loader for BTreeMap<IriBuf, RemoteDocument> {
-	type Error = EntryNotFound;
-
-	async fn load(&mut self, url: &Iri) -> LoadingResult<IriBuf, Self::Error> {
+	async fn load(&self, url: &Iri) -> LoadingResult<IriBuf> {
 		match self.get(url) {
 			Some(document) => Ok(document.clone()),
-			None => Err(EntryNotFound(url.to_owned())),
+			None => Err(LoadError::new(url.to_owned(), EntryNotFound)),
 		}
 	}
 }

--- a/crates/core/src/loader/mod.rs
+++ b/crates/core/src/loader/mod.rs
@@ -20,7 +20,7 @@ pub mod reqwest;
 #[cfg(feature = "reqwest")]
 pub use self::reqwest::ReqwestLoader;
 
-pub type LoadingResult<I, E> = Result<RemoteDocument<I>, E>;
+pub type LoadingResult<I = IriBuf> = Result<RemoteDocument<I>, LoadError>;
 
 pub type RemoteContextReference<I = IriBuf> = RemoteDocumentReference<I, json_ld_syntax::Context>;
 
@@ -51,14 +51,10 @@ impl<I> RemoteDocumentReference<I> {
 	///
 	/// If the document is already [`Self::Loaded`], simply returns the inner
 	/// [`RemoteDocument`].
-	pub async fn load_with<V, L: Loader>(
-		self,
-		vocabulary: &mut V,
-		loader: &mut L,
-	) -> Result<RemoteDocument<I>, L::Error>
+	pub async fn load_with<V>(self, vocabulary: &mut V, loader: &impl Loader) -> LoadingResult<I>
 	where
 		V: IriVocabularyMut<Iri = I>,
-		I: Clone + Eq + Hash
+		I: Clone + Eq + Hash,
 	{
 		match self {
 			Self::Iri(r) => Ok(loader.load_with(vocabulary, r).await?.map(Into::into)),
@@ -72,14 +68,14 @@ impl<I> RemoteDocumentReference<I> {
 	/// [`Cow::Owned`].
 	/// For [`Self::Loaded`] returns a reference to the inner [`RemoteDocument`]
 	/// with [`Cow::Borrowed`].
-	pub async fn loaded_with<V, L: Loader>(
+	pub async fn loaded_with<V>(
 		&self,
 		vocabulary: &mut V,
-		loader: &mut L,
-	) -> Result<Cow<'_, RemoteDocument<V::Iri>>, L::Error>
+		loader: &impl Loader,
+	) -> Result<Cow<'_, RemoteDocument<V::Iri>>, LoadError>
 	where
 		V: IriVocabularyMut<Iri = I>,
-		I: Clone + Eq + Hash
+		I: Clone + Eq + Hash,
 	{
 		match self {
 			Self::Iri(r) => Ok(Cow::Owned(
@@ -95,18 +91,11 @@ impl<I> RemoteDocumentReference<I> {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ContextLoadError {
-	#[error("loading document `{0}` failed: {0}")]
-	LoadingDocumentFailed(IriBuf, String),
+	#[error(transparent)]
+	LoadingDocumentFailed(#[from] LoadError),
 
 	#[error("context extraction failed")]
 	ContextExtractionFailed(#[from] ExtractContextError),
-}
-
-impl ContextLoadError {
-	fn from_loader_error(e: impl LoaderError) -> Self {
-		let (iri, message) = e.into_iri_and_message();
-		Self::LoadingDocumentFailed(iri, message)
-	}
 }
 
 impl<I> RemoteContextReference<I> {
@@ -117,20 +106,16 @@ impl<I> RemoteContextReference<I> {
 	pub async fn load_context_with<V, L: Loader>(
 		self,
 		vocabulary: &mut V,
-		loader: &mut L,
+		loader: &L,
 	) -> Result<RemoteContext<I>, ContextLoadError>
 	where
 		V: IriVocabularyMut<Iri = I>,
-		I: Clone + Eq + Hash
+		I: Clone + Eq + Hash,
 	{
 		match self {
 			Self::Iri(r) => Ok(loader
 				.load_with(vocabulary, r)
-				.await
-				.map_err(|e| {
-					let (iri, message) = e.into_iri_and_message();
-					ContextLoadError::LoadingDocumentFailed(iri, message)
-				})?
+				.await?
 				.try_map(|d| d.into_ld_context())?),
 			Self::Loaded(doc) => Ok(doc),
 		}
@@ -145,7 +130,7 @@ impl<I> RemoteContextReference<I> {
 	pub async fn loaded_context_with<V, L: Loader>(
 		&self,
 		vocabulary: &mut V,
-		loader: &mut L,
+		loader: &L,
 	) -> Result<Cow<'_, RemoteContext<I>>, ContextLoadError>
 	where
 		V: IriVocabularyMut<Iri = I>,
@@ -155,8 +140,7 @@ impl<I> RemoteContextReference<I> {
 			Self::Iri(r) => Ok(Cow::Owned(
 				loader
 					.load_with(vocabulary, r.clone())
-					.await
-					.map_err(ContextLoadError::from_loader_error)?
+					.await?
 					.try_map(|d| d.into_ld_context())?,
 			)),
 			Self::Loaded(doc) => Ok(Cow::Borrowed(doc)),
@@ -260,13 +244,17 @@ impl<I, T> RemoteDocument<I, T> {
 	/// Maps all the IRIs.
 	pub fn map_iris<J>(self, mut f: impl FnMut(I) -> J) -> RemoteDocument<J, T>
 	where
-		J: Eq + Hash
+		J: Eq + Hash,
 	{
 		RemoteDocument {
 			url: self.url.map(&mut f),
 			content_type: self.content_type,
 			context_url: self.context_url.map(&mut f),
-			profile: self.profile.into_iter().map(|p| p.map_iri(&mut f)).collect(),
+			profile: self
+				.profile
+				.into_iter()
+				.map(|p| p.map_iri(&mut f))
+				.collect(),
 			document: self.document,
 		}
 	}
@@ -396,7 +384,7 @@ impl Profile {
 	pub fn iri(&self) -> &Iri {
 		match self {
 			Self::Standard(s) => s.iri(),
-			Self::Custom(c) => c
+			Self::Custom(c) => c,
 		}
 	}
 }
@@ -419,14 +407,28 @@ impl<I> Profile<I> {
 	pub fn map_iri<J>(self, f: impl FnOnce(I) -> J) -> Profile<J> {
 		match self {
 			Self::Standard(p) => Profile::Standard(p),
-			Self::Custom(i) => Profile::Custom(f(i))
+			Self::Custom(i) => Profile::Custom(f(i)),
 		}
 	}
 }
 
-/// Loader error.
-pub trait LoaderError {
-	fn into_iri_and_message(self) -> (IriBuf, String);
+pub type LoadErrorCause = Box<dyn std::error::Error + Send + Sync>;
+
+/// Loading error.
+#[derive(Debug, thiserror::Error)]
+#[error("loading document `{target}` failed: {cause}")]
+pub struct LoadError {
+	pub target: IriBuf,
+	pub cause: LoadErrorCause,
+}
+
+impl LoadError {
+	pub fn new(target: IriBuf, cause: impl 'static + std::error::Error + Send + Sync) -> Self {
+		Self {
+			target,
+			cause: Box::new(cause),
+		}
+	}
 }
 
 /// Document loader.
@@ -449,40 +451,33 @@ pub trait LoaderError {
 ///     [`reqwest`](https://crates.io/crates/reqwest) library.
 ///     This requires the `reqwest` feature to be enabled.
 pub trait Loader {
-	/// Error type.
-	type Error: LoaderError;
-
 	/// Loads the document behind the given IRI, using the given vocabulary.
 	#[allow(async_fn_in_trait)]
-	async fn load_with<V>(&mut self, vocabulary: &mut V, url: V::Iri) -> LoadingResult<V::Iri, Self::Error>
+	async fn load_with<V>(&self, vocabulary: &mut V, url: V::Iri) -> LoadingResult<V::Iri>
 	where
 		V: IriVocabularyMut,
-		V::Iri: Clone + Eq + Hash
+		V::Iri: Clone + Eq + Hash,
 	{
 		let lexical_url = vocabulary.iri(&url).unwrap();
 		let document = self.load(lexical_url).await?;
-		Ok(document.map_iris(|i| {
-			vocabulary.insert_owned(i)
-		}))
+		Ok(document.map_iris(|i| vocabulary.insert_owned(i)))
 	}
 
 	/// Loads the document behind the given IRI.
 	#[allow(async_fn_in_trait)]
-	async fn load(&mut self, url: &Iri) -> Result<RemoteDocument<IriBuf>, Self::Error>;
+	async fn load(&self, url: &Iri) -> Result<RemoteDocument<IriBuf>, LoadError>;
 }
 
 impl<'l, L: Loader> Loader for &'l mut L {
-	type Error = L::Error;
-
-	async fn load_with<V>(&mut self, vocabulary: &mut V, url: V::Iri) -> LoadingResult<V::Iri, Self::Error>
+	async fn load_with<V>(&self, vocabulary: &mut V, url: V::Iri) -> LoadingResult<V::Iri>
 	where
 		V: IriVocabularyMut,
-		V::Iri: Clone + Eq + Hash
+		V::Iri: Clone + Eq + Hash,
 	{
 		L::load_with(self, vocabulary, url).await
 	}
 
-	async fn load(&mut self, url: &Iri) -> Result<RemoteDocument<IriBuf>, Self::Error> {
+	async fn load(&self, url: &Iri) -> Result<RemoteDocument<IriBuf>, LoadError> {
 		L::load(self, url).await
 	}
 }

--- a/crates/core/src/loader/none.rs
+++ b/crates/core/src/loader/none.rs
@@ -1,6 +1,6 @@
 use super::Loader;
-use crate::{LoaderError, LoadingResult};
-use iref::{Iri, IriBuf};
+use crate::{LoadError, LoadingResult};
+use iref::Iri;
 
 /// Dummy loader.
 ///
@@ -12,20 +12,12 @@ use iref::{Iri, IriBuf};
 pub struct NoLoader;
 
 #[derive(Debug, thiserror::Error)]
-#[error("no loader for `{0}`")]
-pub struct CannotLoad(pub IriBuf);
-
-impl LoaderError for CannotLoad {
-	fn into_iri_and_message(self) -> (IriBuf, String) {
-		(self.0, "no loader".to_string())
-	}
-}
+#[error("no loader")]
+pub struct CannotLoad;
 
 impl Loader for NoLoader {
-	type Error = CannotLoad;
-
 	#[inline(always)]
-	async fn load(&mut self, url: &Iri) -> LoadingResult<IriBuf, CannotLoad> {
-		Err(CannotLoad(url.to_owned()))
+	async fn load(&self, url: &Iri) -> LoadingResult {
+		Err(LoadError::new(url.to_owned(), CannotLoad))
 	}
 }

--- a/crates/core/src/loader/none.rs
+++ b/crates/core/src/loader/none.rs
@@ -1,7 +1,6 @@
 use super::Loader;
 use crate::{LoaderError, LoadingResult};
-use iref::IriBuf;
-use rdf_types::vocabulary::IriVocabulary;
+use iref::{Iri, IriBuf};
 
 /// Dummy loader.
 ///
@@ -22,14 +21,11 @@ impl LoaderError for CannotLoad {
 	}
 }
 
-impl<I> Loader<I> for NoLoader {
+impl Loader for NoLoader {
 	type Error = CannotLoad;
 
 	#[inline(always)]
-	async fn load_with<V>(&mut self, vocabulary: &mut V, url: I) -> LoadingResult<I, CannotLoad>
-	where
-		V: IriVocabulary<Iri = I>,
-	{
-		Err(CannotLoad(vocabulary.owned_iri(url).ok().unwrap()))
+	async fn load(&mut self, url: &Iri) -> LoadingResult<IriBuf, CannotLoad> {
+		Err(CannotLoad(url.to_owned()))
 	}
 }

--- a/crates/expansion/src/array.rs
+++ b/crates/expansion/src/array.rs
@@ -20,7 +20,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,
 	N::BlankId: Clone + Eq + Hash,
-	L: Loader<N::Iri>,
+	L: Loader,
 	W: WarningHandler<N>,
 {
 	// Initialize an empty array, result.

--- a/crates/expansion/src/document.rs
+++ b/crates/expansion/src/document.rs
@@ -21,7 +21,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,
 	N::BlankId: Clone + Eq + Hash,
-	L: Loader<N::Iri>,
+	L: Loader,
 	W: WarningHandler<N>,
 {
 	let expanded = expand_element(

--- a/crates/expansion/src/element.rs
+++ b/crates/expansion/src/element.rs
@@ -82,7 +82,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,
 	N::BlankId: Clone + Eq + Hash,
-	L: Loader<N::Iri>,
+	L: Loader,
 	W: WarningHandler<N>,
 {
 	// If `element` is null, return null.

--- a/crates/expansion/src/lib.rs
+++ b/crates/expansion/src/lib.rs
@@ -120,7 +120,7 @@ pub trait Expand<Iri> {
 		vocabulary: &'a mut N,
 		context: Context<Iri, N::BlankId>,
 		base_url: Option<&'a N::Iri>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 		warnings_handler: W,
 	) -> ExpansionResult<N::Iri, N::BlankId>
@@ -142,7 +142,7 @@ pub trait Expand<Iri> {
 	async fn expand_with<'a, N, L>(
 		&'a self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a L,
 	) -> ExpansionResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
@@ -168,7 +168,7 @@ pub trait Expand<Iri> {
 	/// The expansion algorithm is called with an empty initial context with
 	/// a base URL given by [`Expand::default_base_url`].
 	#[allow(async_fn_in_trait)]
-	async fn expand<'a, L>(&'a self, loader: &'a mut L) -> ExpansionResult<Iri, BlankIdBuf>
+	async fn expand<'a, L>(&'a self, loader: &'a L) -> ExpansionResult<Iri, BlankIdBuf>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
@@ -190,7 +190,7 @@ impl<Iri> Expand<Iri> for Value {
 		vocabulary: &'a mut N,
 		context: Context<Iri, N::BlankId>,
 		base_url: Option<&'a Iri>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 		mut warnings_handler: W,
 	) -> ExpansionResult<Iri, N::BlankId>
@@ -230,7 +230,7 @@ impl<Iri> Expand<Iri> for RemoteDocument<Iri> {
 		vocabulary: &'a mut N,
 		context: Context<Iri, N::BlankId>,
 		base_url: Option<&'a Iri>,
-		loader: &'a mut L,
+		loader: &'a L,
 		options: Options,
 		warnings_handler: W,
 	) -> ExpansionResult<Iri, N::BlankId>

--- a/crates/expansion/src/lib.rs
+++ b/crates/expansion/src/lib.rs
@@ -128,7 +128,7 @@ pub trait Expand<Iri> {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 		W: 'a + WarningHandler<N>;
 
 	/// Expand the input JSON-LD document with the given `vocabulary`
@@ -148,7 +148,7 @@ pub trait Expand<Iri> {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.expand_full(
 			vocabulary,
@@ -172,7 +172,7 @@ pub trait Expand<Iri> {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.expand_with(vocabulary::no_vocabulary_mut(), loader)
 			.await
@@ -198,7 +198,7 @@ impl<Iri> Expand<Iri> for Value {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 		W: 'a + WarningHandler<N>,
 	{
 		document::expand(
@@ -238,7 +238,7 @@ impl<Iri> Expand<Iri> for RemoteDocument<Iri> {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 		W: 'a + WarningHandler<N>,
 	{
 		self.document()

--- a/crates/expansion/src/node.rs
+++ b/crates/expansion/src/node.rs
@@ -40,7 +40,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,
 	N::BlankId: Clone + Eq + Hash,
-	L: Loader<N::Iri>,
+	L: Loader,
 	W: WarningHandler<N>,
 {
 	// Initialize two empty maps, `result` and `nests`.
@@ -118,7 +118,7 @@ where
 	N: VocabularyMut,
 	N::Iri: Clone + Eq + Hash,
 	N::BlankId: Clone + Eq + Hash,
-	L: Loader<N::Iri>,
+	L: Loader,
 	W: WarningHandler<N>,
 {
 	// For each `key` and `value` in `element`, ordered lexicographically by key

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -3,7 +3,7 @@
 use async_std::task;
 use contextual::{DisplayWithContext, WithContext};
 use iref::{IriBuf, IriRefBuf};
-use json_ld::{Expand, FsLoader, ValidId};
+use json_ld::{Expand, FsLoader, LoadError, ValidId};
 use proc_macro2::TokenStream;
 use proc_macro_error::proc_macro_error;
 use quote::quote;
@@ -477,7 +477,7 @@ fn parse_enum_type(
 
 enum Error {
 	Parse(syn::Error),
-	Load(json_ld::loader::fs::Error),
+	Load(LoadError),
 	Expand(json_ld::expansion::Error),
 	InvalidIri(String),
 	InvalidValue(
@@ -527,7 +527,7 @@ impl DisplayWithContext<IndexVocabulary> for Error {
 
 async fn generate_test_suite(
 	vocabulary: &mut IndexVocabulary,
-	mut loader: FsLoader,
+	loader: FsLoader,
 	spec: TestSpec,
 ) -> Result<TokenStream, Box<Error>> {
 	use json_ld::{Loader, RdfQuads};
@@ -538,7 +538,7 @@ async fn generate_test_suite(
 		.map_err(Error::Load)?;
 
 	let mut expanded_json_ld: json_ld::ExpandedDocument<IriIndex, BlankIdIndex> = json_ld
-		.expand_with(vocabulary, &mut loader)
+		.expand_with(vocabulary, &loader)
 		.await
 		.map_err(Error::Expand)?;
 

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -3,7 +3,7 @@
 use async_std::task;
 use contextual::{DisplayWithContext, WithContext};
 use iref::{IriBuf, IriRefBuf};
-use json_ld::{Expand, ValidId};
+use json_ld::{Expand, FsLoader, ValidId};
 use proc_macro2::TokenStream;
 use proc_macro_error::proc_macro_error;
 use quote::quote;
@@ -22,8 +22,6 @@ mod vocab;
 use vocab::{BlankIdIndex, IndexQuad, IndexTerm, IriIndex, Vocab};
 mod ty;
 use ty::{Type, UnknownType};
-
-type FsLoader = json_ld::FsLoader<IriIndex>;
 
 type IndexVocabulary = rdf_types::vocabulary::IndexVocabulary<IriIndex, BlankIdIndex>;
 
@@ -235,7 +233,7 @@ fn parse_input(
 	for attr in attrs {
 		if attr.path.is_ident("mount") {
 			let mount: MountAttribute = syn::parse2(attr.tokens).map_err(|e| Box::new(e.into()))?;
-			loader.mount(vocabulary.insert(mount.prefix.as_iri()), mount.target)
+			loader.mount(mount.prefix.as_iri().to_owned(), mount.target)
 		} else if attr.path.is_ident("iri_prefix") {
 			let attr: PrefixBinding = syn::parse2(attr.tokens).map_err(|e| Box::new(e.into()))?;
 			bindings.insert(attr.prefix, vocabulary.insert(attr.iri.as_iri()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 //! // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 //! // the local `example` directory. No HTTP query.
 //! let mut loader = json_ld::FsLoader::default();
-//! loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+//! loader.mount(iri!("https://example.com/").to_owned(), "examples");
 //!
 //! let expanded = input
 //!   .expand_with(&mut vocabulary, &mut loader)

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -383,7 +383,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>;
+		L: Loader;
 
 	/// Compare this document against `other` with a custom vocabulary using the
 	/// given `options`.
@@ -430,7 +430,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.compare_full(other, vocabulary, loader, options, ())
 			.await
@@ -480,7 +480,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.compare_with_using(other, vocabulary, loader, Options::default())
 			.await
@@ -525,7 +525,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.compare_with_using(
 			other,
@@ -570,7 +570,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.compare_with(other, rdf_types::vocabulary::no_vocabulary_mut(), loader)
 			.await
@@ -624,7 +624,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>;
+		L: Loader;
 
 	/// Expand the document with the given `vocabulary` and `loader`, using
 	/// the given `options`.
@@ -673,7 +673,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.expand_full(vocabulary, loader, options, ()).await
 	}
@@ -723,7 +723,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.expand_with_using(vocabulary, loader, Options::default())
 			.await
@@ -768,7 +768,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.expand_with_using(vocabulary::no_vocabulary_mut(), loader, options)
 			.await
@@ -807,7 +807,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.expand_with(vocabulary::no_vocabulary_mut(), loader)
 			.await
@@ -825,7 +825,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>;
+		L: Loader;
 
 	#[allow(async_fn_in_trait)]
 	async fn into_document_with_using<'a, N, L>(
@@ -838,7 +838,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.into_document_full(vocabulary, loader, options, ())
 			.await
@@ -854,7 +854,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.into_document_with_using(vocabulary, loader, Options::default())
 			.await
@@ -865,7 +865,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.into_document_with(vocabulary::no_vocabulary_mut(), loader)
 			.await
@@ -925,7 +925,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>;
+		L: Loader;
 
 	/// Compact the document relative to `context` with the given `vocabulary`
 	/// and `loader`, using the given `options`.
@@ -980,7 +980,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.compact_full(vocabulary, context, loader, options, ())
 			.await
@@ -1038,7 +1038,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.compact_with_using(vocabulary, context, loader, Options::default())
 			.await
@@ -1090,7 +1090,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.compact_with_using(vocabulary::no_vocabulary_mut(), context, loader, options)
 			.await
@@ -1140,7 +1140,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.compact_with(vocabulary::no_vocabulary_mut(), context, loader)
 			.await
@@ -1211,7 +1211,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>;
+		L: Loader;
 
 	/// Flatten the document with the given `vocabulary`, `generator`
 	/// and `loader`, using the given `options`.
@@ -1273,7 +1273,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.flatten_full(vocabulary, generator, None, loader, options, ())
 			.await
@@ -1338,7 +1338,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.flatten_with_using(vocabulary, generator, loader, Options::default())
 			.await
@@ -1396,7 +1396,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.flatten_with_using(vocabulary::no_vocabulary_mut(), generator, loader, options)
 			.await
@@ -1452,7 +1452,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.flatten_with(vocabulary::no_vocabulary_mut(), generator, loader)
 			.await
@@ -1528,7 +1528,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
 		G: Generator<N>,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		let rdf_direction = options.rdf_direction;
 		let produce_generalized_rdf = options.produce_generalized_rdf;
@@ -1613,7 +1613,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
 		G: Generator<N>,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.to_rdf_full(vocabulary, generator, loader, options, ())
 			.await
@@ -1686,7 +1686,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
 		G: Generator<N>,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.to_rdf_full(vocabulary, generator, loader, Options::default(), ())
 			.await
@@ -1759,7 +1759,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		G: Generator,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.to_rdf_with_using(
 			rdf_types::vocabulary::no_vocabulary_mut(),
@@ -1837,7 +1837,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		G: Generator,
-		L: Loader<Iri>,
+		L: Loader,
 	{
 		self.to_rdf_using(generator, loader, Options::default())
 			.await
@@ -1941,7 +1941,7 @@ where
 	N::Iri: Clone + Eq + Hash,
 	N::BlankId: 'a + Clone + Eq + Hash,
 	T: Compact<N::Iri, N::BlankId>,
-	L: Loader<N::Iri>,
+	L: Loader,
 {
 	let context_base = url.or(options.base.as_ref());
 

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -5,7 +5,7 @@ use crate::syntax::ErrorCode;
 use crate::{flattening::ConflictingIndexes, Context, ExpandedDocument, Loader, ProcessingMode};
 use iref::IriBuf;
 use json_ld_core::rdf::RdfDirection;
-use json_ld_core::{ContextLoadError, LoaderError};
+use json_ld_core::{ContextLoadError, LoadError};
 use json_ld_core::{Document, RdfQuads, RemoteContextReference};
 use rdf_types::{vocabulary, BlankIdBuf, Generator, Vocabulary, VocabularyMut};
 use std::hash::Hash;
@@ -154,25 +154,20 @@ pub enum ExpandError {
 	ContextProcessing(context_processing::Error),
 
 	/// Remote document loading failed with the given precise error.
-	#[error("Remote document `{0}` loading failed: {1}")]
-	Loading(IriBuf, String),
+	#[error(transparent)]
+	Loading(#[from] LoadError),
 
 	#[error(transparent)]
 	ContextLoading(ContextLoadError),
 }
 
 impl ExpandError {
-	pub fn from_loader_error(e: impl LoaderError) -> Self {
-		let (iri, message) = e.into_iri_and_message();
-		Self::Loading(iri, message)
-	}
-
 	/// Returns the code of this error.
 	pub fn code(&self) -> ErrorCode {
 		match self {
 			Self::Expansion(e) => e.code(),
 			Self::ContextProcessing(e) => e.code(),
-			Self::Loading(_, _) => ErrorCode::LoadingDocumentFailed,
+			Self::Loading(_) => ErrorCode::LoadingDocumentFailed,
 			Self::ContextLoading(_) => ErrorCode::LoadingRemoteContextFailed,
 		}
 	}
@@ -200,26 +195,21 @@ pub enum CompactError {
 	Compaction(compaction::Error),
 
 	/// Remote document loading failed.
-	#[error("Remote document `{0}` loading failed: {1}")]
-	Loading(IriBuf, String),
+	#[error(transparent)]
+	Loading(#[from] LoadError),
 
 	#[error(transparent)]
 	ContextLoading(ContextLoadError),
 }
 
 impl CompactError {
-	pub fn from_loader_error(e: impl LoaderError) -> Self {
-		let (iri, message) = e.into_iri_and_message();
-		Self::Loading(iri, message)
-	}
-
 	/// Returns the code of this error.
 	pub fn code(&self) -> ErrorCode {
 		match self {
 			Self::Expand(e) => e.code(),
 			Self::ContextProcessing(e) => e.code(),
 			Self::Compaction(e) => e.code(),
-			Self::Loading(_, _) => ErrorCode::LoadingDocumentFailed,
+			Self::Loading(_) => ErrorCode::LoadingDocumentFailed,
 			Self::ContextLoading(_) => ErrorCode::LoadingRemoteContextFailed,
 		}
 	}
@@ -240,26 +230,21 @@ pub enum FlattenError<I, B> {
 	#[error("Conflicting indexes: {0}")]
 	ConflictingIndexes(ConflictingIndexes<I, B>),
 
-	#[error("Remote document loading failed: {0}")]
-	Loading(IriBuf, String),
+	#[error(transparent)]
+	Loading(#[from] LoadError),
 
 	#[error(transparent)]
 	ContextLoading(ContextLoadError),
 }
 
 impl<I, B> FlattenError<I, B> {
-	pub fn from_loader_error(e: impl LoaderError) -> Self {
-		let (iri, message) = e.into_iri_and_message();
-		Self::Loading(iri, message)
-	}
-
 	/// Returns the code of this error.
 	pub fn code(&self) -> ErrorCode {
 		match self {
 			Self::Expand(e) => e.code(),
 			Self::Compact(e) => e.code(),
 			Self::ConflictingIndexes(_) => ErrorCode::ConflictingIndexes,
-			Self::Loading(_, _) => ErrorCode::LoadingDocumentFailed,
+			Self::Loading(_) => ErrorCode::LoadingDocumentFailed,
 			Self::ContextLoading(_) => ErrorCode::LoadingRemoteContextFailed,
 		}
 	}
@@ -332,7 +317,7 @@ pub type CompareResult = Result<bool, ExpandError>;
 /// let mut loader = json_ld::FsLoader::default();
 /// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 ///
-/// let expanded = input.expand(&mut loader)
+/// let expanded = input.expand(&loader)
 ///   .await
 ///   .expect("expansion failed");
 /// # }
@@ -359,31 +344,30 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///  
 	/// assert!(input1.compare_full(
 	///   &input2,
 	///   &mut vocabulary,
-	///   &mut loader,
+	///   &loader,
 	///   Options::default(),
 	///   warning::PrintWith
 	/// ).await.expect("comparison failed"));
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compare_full<'a, N, L>(
+	async fn compare_full<'a, N>(
 		&'a self,
 		other: &'a Self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> CompareResult
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader;
+		N::BlankId: 'a + Clone + Eq + Hash;
 
 	/// Compare this document against `other` with a custom vocabulary using the
 	/// given `options`.
@@ -408,29 +392,28 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///  
 	/// assert!(input1.compare_with_using(
 	///   &input2,
 	///   &mut vocabulary,
-	///   &mut loader,
+	///   &loader,
 	///   Options::default()
 	/// ).await.expect("comparison failed"));
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compare_with_using<'a, N, L>(
+	async fn compare_with_using<'a, N>(
 		&'a self,
 		other: &'a Self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> CompareResult
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.compare_full(other, vocabulary, loader, options, ())
 			.await
@@ -460,27 +443,26 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///  
 	/// assert!(input1.compare_with(
 	///   &input2,
 	///   &mut vocabulary,
-	///   &mut loader
+	///   &loader
 	/// ).await.expect("comparison failed"));
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compare_with<'a, N, L>(
+	async fn compare_with<'a, N>(
 		&'a self,
 		other: &'a Self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> CompareResult
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.compare_with_using(other, vocabulary, loader, Options::default())
 			.await
@@ -510,22 +492,21 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///  
 	/// assert!(input1.compare_using(
 	///   &input2,
-	///   &mut loader,
+	///   &loader,
 	///   Options::default()
 	/// ).await.expect("comparison failed"));
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compare_using<'a, L>(
+	async fn compare_using<'a>(
 		&'a self,
 		other: &'a Self,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> CompareResult
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.compare_with_using(
 			other,
@@ -561,16 +542,15 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///  
 	/// assert!(input1.compare(
 	///   &input2,
-	///   &mut loader
+	///   &loader
 	/// ).await.expect("comparison failed"));
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compare<'a, L>(&'a self, other: &'a Self, loader: &'a mut L) -> CompareResult
+	async fn compare<'a>(&'a self, other: &'a Self, loader: &'a impl Loader) -> CompareResult
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.compare_with(other, rdf_types::vocabulary::no_vocabulary_mut(), loader)
 			.await
@@ -599,12 +579,12 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let expanded = input
 	///   .expand_full(
 	///     &mut vocabulary,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default(),
 	///     warning::PrintWith
 	///   )
@@ -613,18 +593,17 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn expand_full<'a, N, L>(
+	async fn expand_full<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> ExpandResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader;
+		N::BlankId: 'a + Clone + Eq + Hash;
 
 	/// Expand the document with the given `vocabulary` and `loader`, using
 	/// the given `options`.
@@ -650,12 +629,12 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let expanded = input
 	///   .expand_with_using(
 	///     &mut vocabulary,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default()
 	///   )
 	///   .await
@@ -663,17 +642,16 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn expand_with_using<'a, N, L>(
+	async fn expand_with_using<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> ExpandResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.expand_full(vocabulary, loader, options, ()).await
 	}
@@ -702,28 +680,27 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let expanded = input
 	///   .expand_with(
 	///     &mut vocabulary,
-	///     &mut loader
+	///     &loader
 	///   )
 	///   .await
 	///   .expect("expansion failed");
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn expand_with<'a, N, L>(
+	async fn expand_with<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> ExpandResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.expand_with_using(vocabulary, loader, Options::default())
 			.await
@@ -752,7 +729,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///
 	/// let expanded = input
 	///   .expand_using(
-	///     &mut loader,
+	///     &loader,
 	///     Options::default()
 	///   )
 	///   .await
@@ -760,15 +737,14 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn expand_using<'a, L>(
+	async fn expand_using<'a>(
 		&'a self,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> ExpandResult<Iri, BlankIdBuf>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.expand_with_using(vocabulary::no_vocabulary_mut(), loader, options)
 			.await
@@ -797,75 +773,70 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let expanded = input
-	///   .expand(&mut loader)
+	///   .expand(&loader)
 	///   .await
 	///   .expect("expansion failed");
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn expand<'a, L>(&'a self, loader: &'a mut L) -> ExpandResult<Iri, BlankIdBuf>
+	async fn expand<'a>(&'a self, loader: &'a impl Loader) -> ExpandResult<Iri, BlankIdBuf>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.expand_with(vocabulary::no_vocabulary_mut(), loader)
 			.await
 	}
 
 	#[allow(async_fn_in_trait)]
-	async fn into_document_full<'a, N, L>(
+	async fn into_document_full<'a, N>(
 		self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> IntoDocumentResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader;
+		N::BlankId: 'a + Clone + Eq + Hash;
 
 	#[allow(async_fn_in_trait)]
-	async fn into_document_with_using<'a, N, L>(
+	async fn into_document_with_using<'a, N>(
 		self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> IntoDocumentResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.into_document_full(vocabulary, loader, options, ())
 			.await
 	}
 
 	#[allow(async_fn_in_trait)]
-	async fn into_document_with<'a, N, L>(
+	async fn into_document_with<'a, N>(
 		self,
 		vocabulary: &'a mut N,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> IntoDocumentResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.into_document_with_using(vocabulary, loader, Options::default())
 			.await
 	}
 
 	#[allow(async_fn_in_trait)]
-	async fn into_document<'a, L>(self, loader: &'a mut L) -> IntoDocumentResult<Iri, BlankIdBuf>
+	async fn into_document<'a>(self, loader: &'a impl Loader) -> IntoDocumentResult<Iri, BlankIdBuf>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.into_document_with(vocabulary::no_vocabulary_mut(), loader)
 			.await
@@ -898,13 +869,13 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let compact = input
 	///   .compact_full(
 	///     &mut vocabulary,
 	///     context,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default(),
 	///     warning::PrintWith
 	///   )
@@ -913,19 +884,18 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compact_full<'a, N, L>(
+	async fn compact_full<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
 		context: RemoteContextReference<Iri>,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> CompactResult
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader;
+		N::BlankId: 'a + Clone + Eq + Hash;
 
 	/// Compact the document relative to `context` with the given `vocabulary`
 	/// and `loader`, using the given `options`.
@@ -955,13 +925,13 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let compact = input
 	///   .compact_with_using(
 	///     &mut vocabulary,
 	///     context,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default()
 	///   )
 	///   .await
@@ -969,18 +939,17 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compact_with_using<'a, N, L>(
+	async fn compact_with_using<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
 		context: RemoteContextReference<Iri>,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> CompactResult
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.compact_full(vocabulary, context, loader, options, ())
 			.await
@@ -1015,30 +984,29 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let compact = input
 	///   .compact_with(
 	///     &mut vocabulary,
 	///     context,
-	///     &mut loader
+	///     &loader
 	///   )
 	///   .await
 	///   .expect("compaction failed");
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compact_with<'a, N, L>(
+	async fn compact_with<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
 		context: RemoteContextReference<Iri>,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> CompactResult
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.compact_with_using(vocabulary, context, loader, Options::default())
 			.await
@@ -1073,7 +1041,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// let compact = input
 	///   .compact_using(
 	///     context,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default()
 	///   )
 	///   .await
@@ -1081,16 +1049,15 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compact_using<'a, L>(
+	async fn compact_using<'a>(
 		&'a self,
 		context: RemoteContextReference<Iri>,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> CompactResult
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.compact_with_using(vocabulary::no_vocabulary_mut(), context, loader, options)
 			.await
@@ -1125,22 +1092,21 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// let compact = input
 	///   .compact(
 	///     context,
-	///     &mut loader
+	///     &loader
 	///   )
 	///   .await
 	///   .expect("compaction failed");
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn compact<'a, L>(
+	async fn compact<'a>(
 		&'a self,
 		context: RemoteContextReference<Iri>,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> CompactResult
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.compact_with(vocabulary::no_vocabulary_mut(), context, loader)
 			.await
@@ -1180,7 +1146,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let mut generator = rdf_types::generator::Blank::new();
 	///
@@ -1189,7 +1155,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///     &mut vocabulary,
 	///     &mut generator,
 	///     None,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default(),
 	///     warning::PrintWith
 	///   )
@@ -1198,20 +1164,19 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn flatten_full<'a, N, L>(
+	async fn flatten_full<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
 		generator: &'a mut impl Generator<N>,
 		context: Option<RemoteContextReference<Iri>>,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> FlattenResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader;
+		N::BlankId: 'a + Clone + Eq + Hash;
 
 	/// Flatten the document with the given `vocabulary`, `generator`
 	/// and `loader`, using the given `options`.
@@ -1246,7 +1211,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let mut generator = rdf_types::generator::Blank::new();
 	///
@@ -1254,7 +1219,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///   .flatten_with_using(
 	///     &mut vocabulary,
 	///     &mut generator,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default()
 	///   )
 	///   .await
@@ -1262,18 +1227,17 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn flatten_with_using<'a, N, L>(
+	async fn flatten_with_using<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
 		generator: &'a mut impl Generator<N>,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> FlattenResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.flatten_full(vocabulary, generator, None, loader, options, ())
 			.await
@@ -1313,7 +1277,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let mut generator = rdf_types::generator::Blank::new();
 	///
@@ -1321,24 +1285,23 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///   .flatten_with(
 	///     &mut vocabulary,
 	///     &mut generator,
-	///     &mut loader
+	///     &loader
 	///   )
 	///   .await
 	///   .expect("flattening failed");
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn flatten_with<'a, N, L>(
+	async fn flatten_with<'a, N>(
 		&'a self,
 		vocabulary: &'a mut N,
 		generator: &'a mut impl Generator<N>,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> FlattenResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.flatten_with_using(vocabulary, generator, loader, Options::default())
 			.await
@@ -1379,7 +1342,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// let nodes = input
 	///   .flatten_using(
 	///     &mut generator,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default()
 	///   )
 	///   .await
@@ -1387,16 +1350,15 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn flatten_using<'a, L>(
+	async fn flatten_using<'a>(
 		&'a self,
 		generator: &'a mut impl Generator,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> FlattenResult<Iri, BlankIdBuf>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.flatten_with_using(vocabulary::no_vocabulary_mut(), generator, loader, options)
 			.await
@@ -1437,22 +1399,21 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// let nodes = input
 	///   .flatten(
 	///     &mut generator,
-	///     &mut loader
+	///     &loader
 	///   )
 	///   .await
 	///   .expect("flattening failed");
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn flatten<'a, L>(
+	async fn flatten<'a>(
 		&'a self,
 		generator: &'a mut impl Generator,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> FlattenResult<Iri, BlankIdBuf>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		L: Loader,
 	{
 		self.flatten_with(vocabulary::no_vocabulary_mut(), generator, loader)
 			.await
@@ -1494,7 +1455,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let mut generator = rdf_types::generator::Blank::new();
 	///
@@ -1502,7 +1463,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///   .to_rdf_full(
 	///     &mut vocabulary,
 	///     &mut generator,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default(),
 	///     warning::PrintWith
 	///   )
@@ -1515,11 +1476,11 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn to_rdf_full<'a, N, G, L>(
+	async fn to_rdf_full<'a, N, G>(
 		&'a self,
 		vocabulary: &'a mut N,
 		generator: &'a mut G,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> ToRdfResult<'a, N, G>
@@ -1528,7 +1489,6 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
 		G: Generator<N>,
-		L: Loader,
 	{
 		let rdf_direction = options.rdf_direction;
 		let produce_generalized_rdf = options.produce_generalized_rdf;
@@ -1581,7 +1541,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let mut generator = rdf_types::generator::Blank::new();
 	///
@@ -1589,7 +1549,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///   .to_rdf_with_using(
 	///     &mut vocabulary,
 	///     &mut generator,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default()
 	///   )
 	///   .await
@@ -1601,11 +1561,11 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn to_rdf_with_using<'a, N, G, L>(
+	async fn to_rdf_with_using<'a, N, G>(
 		&'a self,
 		vocabulary: &'a mut N,
 		generator: &'a mut G,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> ToRdfResult<'a, N, G>
 	where
@@ -1613,7 +1573,6 @@ pub trait JsonLdProcessor<Iri>: Sized {
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
 		G: Generator<N>,
-		L: Loader,
 	{
 		self.to_rdf_full(vocabulary, generator, loader, options, ())
 			.await
@@ -1656,7 +1615,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// // Use `FsLoader` to redirect any URL starting with `https://example.com/` to
 	/// // the local `example` directory. No HTTP query.
 	/// let mut loader = json_ld::FsLoader::default();
-	/// loader.mount(vocabulary.insert(iri!("https://example.com/")), "examples");
+	/// loader.mount(iri!("https://example.com/").to_owned(), "examples");
 	///
 	/// let mut generator = rdf_types::generator::Blank::new();
 	///
@@ -1664,7 +1623,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	///   .to_rdf_with(
 	///     &mut vocabulary,
 	///     &mut generator,
-	///     &mut loader
+	///     &loader
 	///   )
 	///   .await
 	///   .expect("flattening failed");
@@ -1675,18 +1634,17 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn to_rdf_with<'a, N, G, L>(
+	async fn to_rdf_with<'a, N, G>(
 		&'a self,
 		vocabulary: &'a mut N,
 		generator: &'a mut G,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> ToRdfResult<'a, N, G>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
 		G: Generator<N>,
-		L: Loader,
 	{
 		self.to_rdf_full(vocabulary, generator, loader, Options::default(), ())
 			.await
@@ -1731,7 +1689,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// let mut rdf = input
 	///   .to_rdf_using(
 	///     &mut generator,
-	///     &mut loader,
+	///     &loader,
 	///     Options::default()
 	///   )
 	///   .await
@@ -1749,17 +1707,16 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn to_rdf_using<'a, G, L>(
+	async fn to_rdf_using<'a, G>(
 		&'a self,
 		generator: &'a mut G,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 		options: Options<Iri>,
 	) -> ToRdfResult<'a, (), G>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		G: Generator,
-		L: Loader,
 	{
 		self.to_rdf_with_using(
 			rdf_types::vocabulary::no_vocabulary_mut(),
@@ -1811,7 +1768,7 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// let mut rdf = input
 	///   .to_rdf(
 	///     &mut generator,
-	///     &mut loader
+	///     &loader
 	///   )
 	///   .await
 	///   .expect("flattening failed");
@@ -1828,16 +1785,15 @@ pub trait JsonLdProcessor<Iri>: Sized {
 	/// # }
 	/// ```
 	#[allow(async_fn_in_trait)]
-	async fn to_rdf<'a, G, L>(
+	async fn to_rdf<'a, G>(
 		&'a self,
 		generator: &'a mut G,
-		loader: &'a mut L,
+		loader: &'a impl Loader,
 	) -> ToRdfResult<'a, (), G>
 	where
 		(): VocabularyMut<Iri = Iri>,
 		Iri: 'a + Clone + Eq + Hash,
 		G: Generator,
-		L: Loader,
 	{
 		self.to_rdf_using(generator, loader, Options::default())
 			.await
@@ -1932,7 +1888,7 @@ async fn compact_expanded_full<'a, T, N, L>(
 	url: Option<&'a N::Iri>,
 	vocabulary: &'a mut N,
 	context: RemoteContextReference<N::Iri>,
-	loader: &'a mut L,
+	loader: &'a L,
 	options: Options<N::Iri>,
 	warnings: impl context_processing::WarningHandler<N>,
 ) -> Result<json_syntax::Value, CompactError>

--- a/src/processor/remote_document.rs
+++ b/src/processor/remote_document.rs
@@ -24,7 +24,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		if json_ld_syntax::Compare::compare(self.document(), other.document()) {
 			let a = JsonLdProcessor::expand_full(
@@ -54,7 +54,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let mut active_context = Context::new(options.base.clone().or_else(|| self.url().cloned()));
 
@@ -120,7 +120,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		N: VocabularyMut<Iri = I>,
 		I: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let expanded =
 			JsonLdProcessor::expand_full(&self, vocabulary, loader, options, warnings).await?;
@@ -139,7 +139,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let expanded_input = JsonLdProcessor::expand_full(
 			self,
@@ -176,7 +176,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let expanded_input = JsonLdProcessor::expand_full(
 			self,
@@ -224,7 +224,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let a = self
 			.loaded_with(vocabulary, loader)
@@ -256,7 +256,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let doc = self
 			.loaded_with(vocabulary, loader)
@@ -276,7 +276,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		N: VocabularyMut<Iri = I>,
 		I: 'a + Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let doc = self
 			.load_with(vocabulary, loader)
@@ -297,7 +297,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let doc = self
 			.loaded_with(vocabulary, loader)
@@ -320,7 +320,7 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
 		N::BlankId: 'a + Clone + Eq + Hash,
-		L: Loader<I>,
+		L: Loader,
 	{
 		let doc = self
 			.loaded_with(vocabulary, loader)

--- a/tests/compact.rs
+++ b/tests/compact.rs
@@ -97,9 +97,9 @@ impl compact::Test {
 		}
 
 		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
-		let mut loader: json_ld::FsLoader<IriIndex> = json_ld::FsLoader::default();
+		let mut loader = json_ld::FsLoader::default();
 		loader.mount(
-			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api")),
+			iri!("https://w3c.github.io/json-ld-api").to_owned(),
 			"tests/json-ld-api",
 		);
 

--- a/tests/custom.rs
+++ b/tests/custom.rs
@@ -1,9 +1,8 @@
-use iref::IriBuf;
 use json_ld::{syntax::Parse, JsonLdProcessor, RemoteDocument};
 use static_iref::iri;
 
 async fn custom_01() {
-	let mut loader: json_ld::FsLoader<IriBuf> = json_ld::FsLoader::new();
+	let mut loader = json_ld::FsLoader::new();
 
 	loader.mount(
 		iri!("https://www.w3.org/").to_owned(),

--- a/tests/expand.rs
+++ b/tests/expand.rs
@@ -87,9 +87,9 @@ impl expand::Test {
 		}
 
 		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
-		let mut loader: json_ld::FsLoader<IriIndex> = json_ld::FsLoader::default();
+		let mut loader = json_ld::FsLoader::default();
 		loader.mount(
-			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api")),
+			iri!("https://w3c.github.io/json-ld-api").to_owned(),
 			"tests/json-ld-api",
 		);
 

--- a/tests/flatten.rs
+++ b/tests/flatten.rs
@@ -96,9 +96,9 @@ impl flatten::Test {
 		}
 
 		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
-		let mut loader: json_ld::FsLoader<IriIndex> = json_ld::FsLoader::default();
+		let mut loader = json_ld::FsLoader::default();
 		loader.mount(
-			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api")),
+			iri!("https://w3c.github.io/json-ld-api").to_owned(),
 			"tests/json-ld-api",
 		);
 

--- a/tests/to_rdf.rs
+++ b/tests/to_rdf.rs
@@ -110,9 +110,9 @@ impl to_rdf::Test {
 		}
 
 		let mut vocabulary: IndexVocabulary = IndexVocabulary::new();
-		let mut loader: json_ld::FsLoader<IriIndex> = json_ld::FsLoader::default();
+		let mut loader = json_ld::FsLoader::default();
 		loader.mount(
-			vocabulary.insert(iri!("https://w3c.github.io/json-ld-api")),
+			iri!("https://w3c.github.io/json-ld-api").to_owned(),
 			"tests/json-ld-api",
 		);
 
@@ -154,9 +154,8 @@ impl to_rdf::Test {
 					})
 					.collect();
 
-				let expect_url = vocabulary.insert(expect);
 				let expected_content =
-					std::fs::read_to_string(loader.filepath(&vocabulary, &expect_url).unwrap())
+					std::fs::read_to_string(loader.filepath(&expect).unwrap())
 						.unwrap();
 				let expected_dataset: IndexedBTreeDataset<IndexTerm> =
 					nquads_syntax::GrdfDocument::parse_str(&expected_content)

--- a/tests/to_rdf.rs
+++ b/tests/to_rdf.rs
@@ -155,8 +155,7 @@ impl to_rdf::Test {
 					.collect();
 
 				let expected_content =
-					std::fs::read_to_string(loader.filepath(&expect).unwrap())
-						.unwrap();
+					std::fs::read_to_string(loader.filepath(&expect).unwrap()).unwrap();
 				let expected_dataset: IndexedBTreeDataset<IndexTerm> =
 					nquads_syntax::GrdfDocument::parse_str(&expected_content)
 						.unwrap()


### PR DESCRIPTION
This PR tackles the two last issues of the `Loader` trait:
- its type parameter.
- its mutable nature.

The type parameter is annoying because it basically bounds the loader to a specific `Vocabulary` implementation, but there are many cases where we want to define a loader without committing to a specific vocabulary. The result is often lots of trait bounds everywhere that could be avoided.

The fact that `load` takes a `&mut self` is completely unnecessary. None of the provided loader implementations are mutating anything when `load` is called. The only case where it could be useful is for a loader implementing a cache, but even then we can argue that a cache should not change the functional nature of `load` and should be implemented with interior mutability.

The fact that the loader must be passed with a mutable reference is annoying in many places where we could benefit from providing an immutable `Copy` reference.