### PR TITLE
Add an expansion policy option for `@vocab`.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -44,6 +44,12 @@ pub enum Command {
 		/// Put the expanded document in canonical form.
 		#[clap(short, long)]
 		canonicalize: bool,
+
+		#[clap(long = "no-vocab")]
+		no_vocab: bool,
+
+		#[clap(long = "no-undef")]
+		no_undef: bool,
 	},
 
 	Flatten {
@@ -112,11 +118,21 @@ async fn main() {
 			base_url,
 			relabel,
 			canonicalize,
+			no_vocab,
+			no_undef,
 		} => {
 			let remote_document = get_remote_document(&mut vocabulary, url_or_path, base_url);
 
 			let options = json_ld::Options {
-				expansion_policy: json_ld::expansion::Policy::Strictest,
+				expansion_policy: json_ld::expansion::Policy {
+					invalid: json_ld::expansion::Action::Reject,
+					vocab: if no_vocab {
+						json_ld::expansion::Action::Reject
+					} else {
+						json_ld::expansion::Action::Keep
+					},
+					allow_undefined: !no_undef,
+				},
 				..Default::default()
 			};
 

--- a/crates/context-processing/src/algorithm/mod.rs
+++ b/crates/context-processing/src/algorithm/mod.rs
@@ -181,6 +181,7 @@ where
 						processing_mode: options.processing_mode,
 						override_protected: false,
 						propagate: true,
+						vocab: options.vocab,
 					};
 
 					let r = Box::pin(process_context(
@@ -313,9 +314,11 @@ where
 								&result,
 								Nullable::Some(value.into()),
 								true,
-								true,
-							) {
-								Term::Id(vocab) => result.set_vocabulary(Some(Term::Id(vocab))),
+								Some(options.vocab),
+							)? {
+								Some(Term::Id(vocab)) => {
+									result.set_vocabulary(Some(Term::Id(vocab)))
+								}
 								_ => return Err(Error::InvalidVocabMapping),
 							}
 						}

--- a/crates/context-processing/src/lib.rs
+++ b/crates/context-processing/src/lib.rs
@@ -1,4 +1,5 @@
 //! JSON-LD context processing types and algorithms.
+use algorithm::{Action, RejectVocab};
 pub use json_ld_core::{warning, Context, ProcessingMode};
 use json_ld_core::{ExtractContextError, LoadError, Loader};
 use json_ld_syntax::ErrorCode;
@@ -104,6 +105,15 @@ pub enum Error {
 
 	#[error("Unable to extract JSON-LD context: {0}")]
 	ContextExtractionFailed(ExtractContextError),
+
+	#[error("Use of forbidden `@vocab`")]
+	ForbiddenVocab,
+}
+
+impl From<RejectVocab> for Error {
+	fn from(_value: RejectVocab) -> Self {
+		Self::ForbiddenVocab
+	}
 }
 
 impl Error {
@@ -130,6 +140,7 @@ impl Error {
 			Self::ProtectedTermRedefinition => ErrorCode::ProtectedTermRedefinition,
 			Self::ContextLoadingFailed(_) => ErrorCode::LoadingRemoteContextFailed,
 			Self::ContextExtractionFailed(_) => ErrorCode::LoadingRemoteContextFailed,
+			Self::ForbiddenVocab => ErrorCode::InvalidVocabMapping,
 		}
 	}
 }
@@ -223,6 +234,9 @@ pub struct Options {
 
 	/// Propagate the processed context.
 	pub propagate: bool,
+
+	/// Forbid the use of `@vocab` to expand terms.
+	pub vocab: Action,
 }
 
 impl Options {
@@ -257,6 +271,7 @@ impl Default for Options {
 			processing_mode: ProcessingMode::default(),
 			override_protected: false,
 			propagate: true,
+			vocab: Action::Keep,
 		}
 	}
 }

--- a/crates/expansion/src/error.rs
+++ b/crates/expansion/src/error.rs
@@ -1,3 +1,4 @@
+use json_ld_context_processing::algorithm::RejectVocab;
 use json_ld_syntax::ErrorCode;
 
 #[derive(Debug, thiserror::Error)]
@@ -52,6 +53,15 @@ pub enum Error {
 
 	#[error(transparent)]
 	Value(crate::InvalidValue),
+
+	#[error("Forbidden use of `@vocab`")]
+	ForbiddenVocab,
+}
+
+impl From<RejectVocab> for Error {
+	fn from(_value: RejectVocab) -> Self {
+		Self::ForbiddenVocab
+	}
 }
 
 impl Error {
@@ -74,6 +84,7 @@ impl Error {
 			Self::DuplicateKey(_) => ErrorCode::DuplicateKey,
 			Self::Literal(e) => e.code(),
 			Self::Value(e) => e.code(),
+			Self::ForbiddenVocab => ErrorCode::InvalidVocabMapping,
 		}
 	}
 }

--- a/crates/expansion/src/node.rs
+++ b/crates/expansion/src/node.rs
@@ -1,6 +1,6 @@
 use crate::{
-	expand_element, expand_iri, expand_literal, filter_top_level_item, ActiveProperty, Error,
-	Expanded, ExpandedEntry, LiteralValue, Options, Policy, Warning, WarningHandler,
+	expand_element, expand_iri, expand_literal, filter_top_level_item, Action, ActiveProperty,
+	Error, Expanded, ExpandedEntry, LiteralValue, Options, Warning, WarningHandler,
 };
 use contextual::WithContext;
 use indexmap::IndexSet;
@@ -164,13 +164,14 @@ where
 							// Otherwise, set `expanded_value` to the result of IRI
 							// expanding value using true for document relative and
 							// false for vocab.
-							result.id = node_id_of_term(expand_iri(
+							result.id = expand_iri(
 								&mut env,
 								active_context,
 								Nullable::Some(str_value.into()),
 								true,
-								false,
-							))
+								None,
+							)?
+							.and_then(node_id_of_term);
 						} else {
 							return Err(Error::InvalidIdValue);
 						}
@@ -186,18 +187,18 @@ where
 						// context, and true for document relative.
 						for ty in value {
 							if let Some(str_ty) = ty.as_str() {
-								if let Ok(ty) = expand_iri(
+								if let Some(ty) = expand_iri(
 									&mut env,
 									type_scoped_context,
 									Nullable::Some(str_ty.into()),
 									true,
-									true,
-								)
-								.try_into()
-								{
-									result.types_mut_or_default().push(ty)
-								} else {
-									return Err(Error::InvalidTypeValue);
+									Some(options.policy.vocab),
+								)? {
+									if let Ok(ty) = ty.try_into() {
+										result.types_mut_or_default().push(ty)
+									} else {
+										return Err(Error::InvalidTypeValue);
+									}
 								}
 							} else {
 								return Err(Error::InvalidTypeValue);
@@ -310,24 +311,29 @@ where
 									active_context,
 									Nullable::Some(reverse_key.as_str().into()),
 									false,
-									true,
-								) {
-									Term::Keyword(_) => {
+									Some(options.policy.vocab),
+								)? {
+									Some(Term::Keyword(_)) => {
 										return Err(Error::InvalidReversePropertyMap)
 									}
-									Term::Id(Id::Invalid(_))
-										if options.policy == Policy::Strictest =>
-									{
-										return Err(Error::KeyExpansionFailed(
-											reverse_key.to_string(),
-										))
-									}
-									Term::Id(reverse_prop)
+									Some(Term::Id(reverse_prop))
 										if reverse_prop
 											.with(&*env.vocabulary)
 											.as_str()
-											.contains(':') || options.policy == Policy::Relaxed =>
+											.contains(':') =>
 									{
+										if !reverse_prop.is_valid() {
+											match options.policy.invalid {
+												Action::Keep => (),
+												Action::Drop => continue,
+												Action::Reject => {
+													return Err(Error::KeyExpansionFailed(
+														reverse_key.to_string(),
+													))
+												}
+											}
+										}
+
 										let reverse_expanded_value = Box::pin(expand_element(
 											Environment {
 												vocabulary: env.vocabulary,
@@ -378,11 +384,18 @@ where
 										}
 									}
 									_ => {
-										if options.policy.is_strict() {
+										if options.policy.invalid.is_reject() {
 											return Err(Error::KeyExpansionFailed(
 												reverse_key.to_string(),
 											));
 										}
+
+										if !options.policy.allow_undefined {
+											return Err(Error::KeyExpansionFailed(
+												reverse_key.to_string(),
+											));
+										}
+
 										// otherwise the key is just dropped.
 									}
 								}
@@ -445,17 +458,22 @@ where
 
 								let nested_expanded_entries = nested_entries
 									.into_iter()
-									.map(|Entry { key, value }| {
-										let expanded_key = expand_iri(
+									.filter_map(|Entry { key, value }| {
+										expand_iri(
 											&mut env,
 											active_context.as_ref(),
 											Nullable::Some(key.as_str().into()),
 											false,
-											true,
-										);
-										ExpandedEntry(key, expanded_key, value)
+											Some(options.policy.vocab),
+										)
+										.map(|e| {
+											e.map(|expanded_key| {
+												ExpandedEntry(key, expanded_key, value)
+											})
+										})
+										.transpose()
 									})
-									.collect();
+									.collect::<Result<_, _>>()?;
 
 								let (new_result, new_has_value_object_entries) =
 									Box::pin(expand_node_entries(
@@ -487,14 +505,15 @@ where
 				}
 			}
 
-			Term::Id(Id::Invalid(name)) if options.policy == Policy::Strictest => {
-				return Err(Error::KeyExpansionFailed(name))
-			}
+			Term::Id(prop) if prop.with(&*env.vocabulary).as_str().contains(':') => {
+				if let Id::Invalid(name) = &prop {
+					match options.policy.invalid {
+						Action::Keep => (),
+						Action::Drop => continue,
+						Action::Reject => return Err(Error::KeyExpansionFailed(name.to_owned())),
+					}
+				}
 
-			Term::Id(prop)
-				if prop.with(&*env.vocabulary).as_str().contains(':')
-					|| options.policy == Policy::Relaxed =>
-			{
 				let mut container_mapping = Container::new();
 
 				let key_definition = active_context.get(key);
@@ -571,9 +590,10 @@ where
 												active_context,
 												Nullable::Some(language.as_str().into()),
 												false,
-												true,
-											) == Term::Keyword(Keyword::None)
-											{
+												Some(options.policy.vocab),
+											)? == Some(Term::Keyword(
+												Keyword::None,
+											)) {
 												None
 											} else {
 												let (language, error) =
@@ -722,10 +742,10 @@ where
 									active_context,
 									Nullable::Some(index.as_str().into()),
 									false,
-									true,
-								) {
-									Term::Null | Term::Keyword(Keyword::None) => None,
-									key => Some(key),
+									Some(options.policy.vocab),
+								)? {
+									Some(Term::Null) | Some(Term::Keyword(Keyword::None)) => None,
+									key => key,
 								};
 
 								// If index value is not an array set index value to
@@ -787,6 +807,7 @@ where
 													loader: env.loader,
 													warnings: env.warnings,
 												},
+												options.policy.vocab,
 												active_context,
 												ActiveProperty::Some(index_key),
 												LiteralValue::Inferred(index.as_str().into()),
@@ -799,9 +820,9 @@ where
 												active_context,
 												Nullable::Some(index_key.into()),
 												false,
-												true,
-											) {
-												Term::Id(prop) => prop,
+												Some(options.policy.vocab),
+											)? {
+												Some(Term::Id(prop)) => prop,
 												_ => continue,
 											};
 
@@ -837,13 +858,14 @@ where
 											// result of IRI expanding index using true for
 											// document relative and false for vocab.
 											if let Object::Node(ref mut node) = *item {
-												node.id = node_id_of_term(expand_iri(
+												node.id = expand_iri(
 													&mut env,
 													active_context,
 													Nullable::Some(index.as_str().into()),
 													true,
-													false,
-												))
+													None,
+												)?
+												.and_then(node_id_of_term);
 											}
 										} else if container_mapping.contains(ContainerKind::Type) {
 											// Otherwise, if container mapping includes
@@ -954,12 +976,19 @@ where
 			}
 
 			Term::Id(prop) => {
-				if options.policy.is_strict() {
+				// non-keyword properties that does not include a ':' are skipped.
+				if let Id::Invalid(name) = &prop {
+					match options.policy.invalid {
+						Action::Drop | Action::Keep => (),
+						Action::Reject => return Err(Error::KeyExpansionFailed(name.to_owned())),
+					}
+				}
+
+				if !options.policy.allow_undefined {
 					return Err(Error::KeyExpansionFailed(
-						prop.with(&*env.vocabulary).to_string(),
+						prop.with(env.vocabulary).to_string(),
 					));
 				}
-				// non-keyword properties that does not include a ':' are skipped.
 			}
 		}
 	}

--- a/crates/expansion/src/node.rs
+++ b/crates/expansion/src/node.rs
@@ -195,6 +195,16 @@ where
 									Some(options.policy.vocab),
 								)? {
 									if let Ok(ty) = ty.try_into() {
+										if let Id::Invalid(_) = &ty {
+											match options.policy.invalid {
+												Action::Keep => (),
+												Action::Drop => continue,
+												Action::Reject => {
+													return Err(Error::InvalidTypeValue)
+												}
+											}
+										}
+
 										result.types_mut_or_default().push(ty)
 									} else {
 										return Err(Error::InvalidTypeValue);

--- a/crates/expansion/src/options.rs
+++ b/crates/expansion/src/options.rs
@@ -1,5 +1,7 @@
 use json_ld_core::ProcessingMode;
 
+pub use json_ld_context_processing::algorithm::Action;
+
 /// Expansion options.
 #[derive(Clone, Copy, Default)]
 pub struct Options {
@@ -47,42 +49,25 @@ impl From<Options> for json_ld_context_processing::Options {
 /// expanded document, or to forbid them completely by raising an error.
 /// You can define your preferred policy using one of this type variant
 /// with the [`Options::policy`] field.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Policy {
-	/// Relaxed policy.
-	///
-	/// Undefined keys are always kept in the expanded document
-	/// using the [`Id::Invalid`](json_ld_core::Id::Invalid) variant.
-	Relaxed,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Policy {
+	/// How to expand invalid terms.
+	pub invalid: Action,
 
-	/// Standard policy.
-	///
-	/// Every key that cannot be expanded into an
-	/// IRI or a blank node identifier is dropped unless it contains a `:` character.
-	Standard,
+	/// How to expand valid terms that need a vocabulary mapping
+	/// (`@vocab` keyword).
+	pub vocab: Action,
 
-	/// Strict policy.
-	///
-	/// Every key that cannot be expanded into an IRI or a blank node identifier
-	/// will raise an error unless the term contains a `:` character.
-	Strict,
-
-	/// Strictest policy.
-	///
-	/// Every key that cannot be expanded into an IRI or a blank node identifier
-	/// will raise an error.
-	Strictest,
-}
-
-impl Policy {
-	/// Returns `true` is the policy is `Strict` or `Strictest`.
-	pub fn is_strict(&self) -> bool {
-		matches!(self, Self::Strict | Self::Strictest)
-	}
+	/// How to expand valid terms when there is no vocabulary mapping.
+	pub allow_undefined: bool,
 }
 
 impl Default for Policy {
 	fn default() -> Self {
-		Self::Standard
+		Self {
+			invalid: Action::Keep,
+			vocab: Action::Keep,
+			allow_undefined: true,
+		}
 	}
 }

--- a/examples/vocab.jsonld
+++ b/examples/vocab.jsonld
@@ -1,0 +1,6 @@
+{
+	"@context": {
+		"@vocab": "https://example.org/"
+	},
+	"foo": "Hello World!"
+}


### PR DESCRIPTION
Terms relying on a vocabulary mapping to be expanded cannot be protected like normal term definitions using the `@protected` keyword. This makes it possible to change the body of a JSON-LD document without changing its semantics, even in situations where the shape of the document's body must be protected.

Here is an example. We start with a document having a context defining a vocabulary mapping. 
```json
{
  "@context": { "@vocab": "http://example.org/#" },
  "foo": true,
  "bar": false
}
```
The terms `foo` and `bar` are expanded using the vocabulary mapping into `http://example.org/#foo` and `http://example.org/#bar` respectively. The resulting expanded document is:
```json
{
  "http://example.org/#foo": true,
  "http://example.org/#bar": false,
}
```

Now consider the following document similar to the first one but with a few changes: 
```json
{
  "@context": [
    { "@vocab": "http://example.org/#" },
    {
      "foo": "http://example.org/#bar",
      "bar": "http://example.org/#foo"
    }
  ],
  "foo": false,
  "bar": true
}
```
First, we added a second context that provides actual definitions for `foo` and `bar` bypassing the vocabulary mapping defined in the first context and swapping the identifiers for those terms. Second, we swapped the value of `foo` and `bar`.

If we ignore the JSON-LD context for a moment, we can easily see that the *intentional* semantics of the document has changed, the field values are swapped. But because we added the new context that swapped the initial semantics of the terms, the actual semantics of the document is the same from the point of view of a JSON-LD processor. The expanded documents are the same.

For certain applications this behavior [can be considered a security risk](https://github.com/w3c/vc-data-integrity/issues/272). This is why the `@protected` keyword exists for regular term definitions. However there is no way to prevent that with vocabulary mapping.

As a countermeasure for this unexpected and arguably problematic behavior, I've added a new option to the expansion algorithm. The `policy.vocab` options can now be set to `json_ld::expansion::Action::Reject` which will effectively reject any document that use a vocabulary mapping to expand a term. `@vocab` can still occur in contexts, as long as its not used during expansion. This solution is not ideal, as `@vocab` is an important feature of JSON-LD, but this might be required for some application for now.