### PR TITLE
Make sure `to_rdf` output is `Send`

### DIFF
--- a/crates/expansion/src/lib.rs
+++ b/crates/expansion/src/lib.rs
@@ -115,21 +115,21 @@ pub trait Expand<Iri> {
 	/// The `options` are used to tweak the expansion algorithm.
 	/// The `warning_handler` is called each time a warning is emitted during expansion.
 	#[allow(async_fn_in_trait)]
-	async fn expand_full<'a, N, L, W>(
-		&'a self,
-		vocabulary: &'a mut N,
+	async fn expand_full<N, L, W>(
+		&self,
+		vocabulary: &mut N,
 		context: Context<Iri, N::BlankId>,
-		base_url: Option<&'a N::Iri>,
-		loader: &'a L,
+		base_url: Option<&N::Iri>,
+		loader: &L,
 		options: Options,
 		warnings_handler: W,
 	) -> ExpansionResult<N::Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
+		N::BlankId: Clone + Eq + Hash,
 		L: Loader,
-		W: 'a + WarningHandler<N>;
+		W: WarningHandler<N>;
 
 	/// Expand the input JSON-LD document with the given `vocabulary`
 	/// to interpret identifiers.
@@ -185,21 +185,21 @@ impl<Iri> Expand<Iri> for Value {
 		None
 	}
 
-	async fn expand_full<'a, N, L, W>(
-		&'a self,
-		vocabulary: &'a mut N,
+	async fn expand_full<N, L, W>(
+		&self,
+		vocabulary: &mut N,
 		context: Context<Iri, N::BlankId>,
-		base_url: Option<&'a Iri>,
-		loader: &'a L,
+		base_url: Option<&Iri>,
+		loader: &L,
 		options: Options,
 		mut warnings_handler: W,
 	) -> ExpansionResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
-		Iri: 'a + Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
+		Iri: Clone + Eq + Hash,
+		N::BlankId: Clone + Eq + Hash,
 		L: Loader,
-		W: 'a + WarningHandler<N>,
+		W: WarningHandler<N>,
 	{
 		document::expand(
 			Environment {
@@ -225,21 +225,21 @@ impl<Iri> Expand<Iri> for RemoteDocument<Iri> {
 		self.url()
 	}
 
-	async fn expand_full<'a, N, L, W>(
-		&'a self,
-		vocabulary: &'a mut N,
+	async fn expand_full<N, L, W>(
+		&self,
+		vocabulary: &mut N,
 		context: Context<Iri, N::BlankId>,
-		base_url: Option<&'a Iri>,
-		loader: &'a L,
+		base_url: Option<&Iri>,
+		loader: &L,
 		options: Options,
 		warnings_handler: W,
 	) -> ExpansionResult<Iri, N::BlankId>
 	where
 		N: VocabularyMut<Iri = Iri>,
 		Iri: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
+		N::BlankId: Clone + Eq + Hash,
 		L: Loader,
-		W: 'a + WarningHandler<N>,
+		W: WarningHandler<N>,
 	{
 		self.document()
 			.expand_full(

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -1830,7 +1830,7 @@ impl<V: Vocabulary, G: rdf_types::Generator<V>> ToRdf<V, G> {
 	}
 
 	#[inline(always)]
-	pub fn cloned_quads<'a>(&'a mut self) -> json_ld_core::rdf::ClonedQuads<'a, V, G> {
+	pub fn cloned_quads(&mut self) -> json_ld_core::rdf::ClonedQuads<'_, V, G> {
 		self.quads().cloned()
 	}
 

--- a/src/processor/remote_document.rs
+++ b/src/processor/remote_document.rs
@@ -12,18 +12,18 @@ use rdf_types::{Generator, VocabularyMut};
 use std::hash::Hash;
 
 impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
-	async fn compare_full<'a, N>(
-		&'a self,
-		other: &'a Self,
-		vocabulary: &'a mut N,
-		loader: &'a impl Loader,
+	async fn compare_full<N>(
+		&self,
+		other: &Self,
+		vocabulary: &mut N,
+		loader: &impl Loader,
 		options: Options<I>,
-		mut warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
+		mut warnings: impl context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> CompareResult
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
+		N::BlankId: Clone + Eq + Hash,
 	{
 		if json_ld_syntax::Compare::compare(self.document(), other.document()) {
 			let a = JsonLdProcessor::expand_full(
@@ -42,17 +42,17 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 		}
 	}
 
-	async fn expand_full<'a, N>(
-		&'a self,
-		vocabulary: &'a mut N,
-		loader: &'a impl Loader,
+	async fn expand_full<N>(
+		&self,
+		vocabulary: &mut N,
+		loader: &impl Loader,
 		mut options: Options<I>,
-		mut warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
+		mut warnings: impl context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> ExpandResult<I, N::BlankId>
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
+		N::BlankId: Clone + Eq + Hash,
 	{
 		let mut active_context = Context::new(options.base.clone().or_else(|| self.url().cloned()));
 
@@ -207,18 +207,18 @@ impl<I> JsonLdProcessor<I> for RemoteDocument<I> {
 }
 
 impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
-	async fn compare_full<'a, N>(
-		&'a self,
-		other: &'a Self,
-		vocabulary: &'a mut N,
-		loader: &'a impl Loader,
+	async fn compare_full<N>(
+		&self,
+		other: &Self,
+		vocabulary: &mut N,
+		loader: &impl Loader,
 		options: Options<I>,
-		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
+		warnings: impl context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> CompareResult
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
+		N::BlankId: Clone + Eq + Hash,
 	{
 		let a = self.loaded_with(vocabulary, loader).await?;
 		let b = other.loaded_with(vocabulary, loader).await?;
@@ -233,17 +233,17 @@ impl<I> JsonLdProcessor<I> for RemoteDocumentReference<I, json_syntax::Value> {
 		.await
 	}
 
-	async fn expand_full<'a, N>(
-		&'a self,
-		vocabulary: &'a mut N,
-		loader: &'a impl Loader,
+	async fn expand_full<N>(
+		&self,
+		vocabulary: &mut N,
+		loader: &impl Loader,
 		options: Options<I>,
-		warnings: impl 'a + context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
+		warnings: impl context_processing::WarningHandler<N> + expansion::WarningHandler<N>,
 	) -> ExpandResult<I, N::BlankId>
 	where
 		N: VocabularyMut<Iri = I>,
 		I: Clone + Eq + Hash,
-		N::BlankId: 'a + Clone + Eq + Hash,
+		N::BlankId: Clone + Eq + Hash,
 	{
 		let doc = self.loaded_with(vocabulary, loader).await?;
 		JsonLdProcessor::expand_full(doc.as_ref(), vocabulary, loader, options, warnings).await


### PR DESCRIPTION
The `JsonLdProcessor::to_rdf` function is triggering rust-lang/rust#100013, making it unusable in a multi-threaded environment since the compiler is unable to check that the output (a `Future`) of `to_rdf` is `Send`. The only fix I know is to remove all the lifetime related to this function.

Instead of passing the vocabulary and generator by reference, they are now passed by move. As far as I know this is not an issue since `VocabularyMut` is also implemented for `&mut V` and `Generator` for `&mut G` anyway, so it's still possible to pass them by reference.

This is yet another breaking change though...