### PR TITLE
Fix `Option<Nullable<T>>` deserialization.

### DIFF
--- a/crates/syntax/src/context/definition/mod.rs
+++ b/crates/syntax/src/context/definition/mod.rs
@@ -25,7 +25,12 @@ pub use vocab::*;
 pub struct Definition {
 	#[cfg_attr(
 		feature = "serde",
-		serde(rename = "@base", default, skip_serializing_if = "Option::is_none")
+		serde(
+			rename = "@base",
+			default,
+			deserialize_with = "Nullable::optional",
+			skip_serializing_if = "Option::is_none"
+		)
 	)]
 	pub base: Option<Nullable<IriRefBuf>>,
 
@@ -37,7 +42,12 @@ pub struct Definition {
 
 	#[cfg_attr(
 		feature = "serde",
-		serde(rename = "@language", default, skip_serializing_if = "Option::is_none")
+		serde(
+			rename = "@language",
+			default,
+			deserialize_with = "Nullable::optional",
+			skip_serializing_if = "Option::is_none"
+		)
 	)]
 	pub language: Option<Nullable<LenientLangTagBuf>>,
 
@@ -46,6 +56,7 @@ pub struct Definition {
 		serde(
 			rename = "@direction",
 			default,
+			deserialize_with = "Nullable::optional",
 			skip_serializing_if = "Option::is_none"
 		)
 	)]
@@ -85,7 +96,12 @@ pub struct Definition {
 
 	#[cfg_attr(
 		feature = "serde",
-		serde(rename = "@vocab", default, skip_serializing_if = "Option::is_none")
+		serde(
+			rename = "@vocab",
+			default,
+			deserialize_with = "Nullable::optional",
+			skip_serializing_if = "Option::is_none"
+		)
 	)]
 	pub vocab: Option<Nullable<Vocab>>,
 
@@ -320,5 +336,25 @@ impl<'a> Iterator for SubItems<'a> {
 			Self::Value(d) => d.next(),
 			Self::TermDefinitionFragment(d) => d.next().map(FragmentRef::TermDefinitionFragment),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Definition;
+
+	#[test]
+	fn deserialize_null_vocab() {
+		let definition: Definition = json_syntax::from_value(json_syntax::json!({
+			"@vocab": null
+		}))
+		.unwrap();
+		assert_eq!(definition.vocab, Some(crate::Nullable::Null))
+	}
+
+	#[test]
+	fn deserialize_no_vocab() {
+		let definition: Definition = json_syntax::from_value(json_syntax::json!({})).unwrap();
+		assert_eq!(definition.vocab, None)
 	}
 }

--- a/crates/syntax/src/context/term_definition/mod.rs
+++ b/crates/syntax/src/context/term_definition/mod.rs
@@ -100,13 +100,23 @@ impl From<BlankIdBuf> for Simple {
 pub struct Expanded {
 	#[cfg_attr(
 		feature = "serde",
-		serde(rename = "@id", default, skip_serializing_if = "Option::is_none")
+		serde(
+			rename = "@id",
+			default,
+			deserialize_with = "Nullable::optional",
+			skip_serializing_if = "Option::is_none"
+		)
 	)]
 	pub id: Option<Nullable<Id>>,
 
 	#[cfg_attr(
 		feature = "serde",
-		serde(rename = "@type", default, skip_serializing_if = "Option::is_none")
+		serde(
+			rename = "@type",
+			default,
+			deserialize_with = "Nullable::optional",
+			skip_serializing_if = "Option::is_none"
+		)
 	)]
 	pub type_: Option<Nullable<Type>>,
 
@@ -130,7 +140,12 @@ pub struct Expanded {
 
 	#[cfg_attr(
 		feature = "serde",
-		serde(rename = "@language", default, skip_serializing_if = "Option::is_none")
+		serde(
+			rename = "@language",
+			default,
+			deserialize_with = "Nullable::optional",
+			skip_serializing_if = "Option::is_none"
+		)
 	)]
 	pub language: Option<Nullable<LenientLangTagBuf>>,
 
@@ -139,6 +154,7 @@ pub struct Expanded {
 		serde(
 			rename = "@direction",
 			default,
+			deserialize_with = "Nullable::optional",
 			skip_serializing_if = "Option::is_none"
 		)
 	)]
@@ -149,6 +165,7 @@ pub struct Expanded {
 		serde(
 			rename = "@container",
 			default,
+			deserialize_with = "Nullable::optional",
 			skip_serializing_if = "Option::is_none"
 		)
 	)]

--- a/crates/syntax/src/nullable.rs
+++ b/crates/syntax/src/nullable.rs
@@ -174,3 +174,15 @@ impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for Nullable<T> {
 		Ok(Option::<T>::deserialize(deserializer)?.into())
 	}
 }
+
+#[cfg(feature = "serde")]
+impl<T> Nullable<T> {
+	pub fn optional<'de, D>(deserializer: D) -> Result<Option<Self>, D::Error>
+	where
+		T: serde::Deserialize<'de>,
+		D: serde::Deserializer<'de>,
+	{
+		use serde::Deserialize;
+		Ok(Some(Option::<T>::deserialize(deserializer)?.into()))
+	}
+}


### PR DESCRIPTION
Serde is unable to deserialize `Option<Nullable<T>>` correctly without a custom deserializer. It can causes issues like `{ "@vocab": null }` being deserialized as `{ }`.

In this PR I'm adding a `Nullable::optional` deserializer for `Option<Nullable<T>>` and use it everywhere it is necessary.