### PR TITLE
Remove unused `owning_ref` dependency

### DIFF
--- a/crates/context-processing/Cargo.toml
+++ b/crates/context-processing/Cargo.toml
@@ -20,4 +20,3 @@ futures.workspace = true
 mown.workspace = true
 contextual.workspace = true
 thiserror.workspace = true
-owning_ref = "0.4.1"


### PR DESCRIPTION
I've noticed that the [owning_ref = "0.4.1"](https://github.com/timothee-haudebourg/json-ld/blob/main/crates/context-processing/Cargo.toml#L23) dependency is unused.

If unused should be good to remove it as it's also flagged by the rustsec advisory [RUSTSEC-2022-0040](https://rustsec.org/advisories/RUSTSEC-2022-0040.html) for multiple soundness issues that cause noise when running `cargo audit` or `cargo deny`. 