### PR TITLE
Do not interpret string literals.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.81.0
         with:
           components: rustfmt, clippy
       - name: Check formatting

--- a/crates/compaction/src/iri.rs
+++ b/crates/compaction/src/iri.rs
@@ -451,7 +451,8 @@ where
 								|| (candidate_def.is_some()
 									&& candidate_def
 										.and_then(|def| def.value())
-										.map_or(false, |v| v == var) && value.is_none()))
+										.map_or(false, |v| v == var)
+									&& value.is_none()))
 						{
 							compact_iri = candidate
 						}

--- a/crates/core/src/deserialization/object/value.rs
+++ b/crates/core/src/deserialization/object/value.rs
@@ -2,7 +2,7 @@ use linked_data::{
 	xsd_types, CowRdfTerm, LinkedData, LinkedDataGraph, LinkedDataPredicateObjects,
 	LinkedDataResource, LinkedDataSubject, RdfLiteral, RdfLiteralRef, ResourceInterpretation,
 };
-use rdf_types::{Interpretation, Term, Vocabulary};
+use rdf_types::{Interpretation, LiteralTypeRef, Term, Vocabulary};
 
 use crate::{
 	object::Literal,
@@ -62,11 +62,18 @@ impl<V: Vocabulary, I: Interpretation> LinkedDataResource<I, V> for Value<V::Iri
 
 					CowRdfTerm::Owned(Term::Literal(RdfLiteral::Xsd(value)))
 				}
-				Literal::String(s) => match ty {
-					Some(ty) => CowRdfTerm::from_str(vocabulary, s.as_str(), ty),
-					None => CowRdfTerm::Borrowed(Term::Literal(RdfLiteralRef::Xsd(
-						xsd_types::ValueRef::String(s),
-					))),
+				Literal::String(s) => {
+					CowRdfTerm::Borrowed(Term::Literal(match ty {
+						Some(ty) => {
+							RdfLiteralRef::Any(
+								s.as_str(),
+								LiteralTypeRef::Any(ty)
+							)
+						},
+						None => RdfLiteralRef::Xsd(
+							xsd_types::ValueRef::String(s),
+						),
+					}))
 				},
 			},
 			Self::LangString(s) => match s.language().and_then(|l| l.as_well_formed()) {

--- a/crates/core/src/deserialization/object/value.rs
+++ b/crates/core/src/deserialization/object/value.rs
@@ -62,19 +62,10 @@ impl<V: Vocabulary, I: Interpretation> LinkedDataResource<I, V> for Value<V::Iri
 
 					CowRdfTerm::Owned(Term::Literal(RdfLiteral::Xsd(value)))
 				}
-				Literal::String(s) => {
-					CowRdfTerm::Borrowed(Term::Literal(match ty {
-						Some(ty) => {
-							RdfLiteralRef::Any(
-								s.as_str(),
-								LiteralTypeRef::Any(ty)
-							)
-						},
-						None => RdfLiteralRef::Xsd(
-							xsd_types::ValueRef::String(s),
-						),
-					}))
-				},
+				Literal::String(s) => CowRdfTerm::Borrowed(Term::Literal(match ty {
+					Some(ty) => RdfLiteralRef::Any(s.as_str(), LiteralTypeRef::Any(ty)),
+					None => RdfLiteralRef::Xsd(xsd_types::ValueRef::String(s)),
+				})),
 			},
 			Self::LangString(s) => match s.language().and_then(|l| l.as_well_formed()) {
 				Some(tag) => CowRdfTerm::Owned(Term::Literal(RdfLiteral::Any(

--- a/crates/core/src/object/mod.rs
+++ b/crates/core/src/object/mod.rs
@@ -35,7 +35,7 @@ pub trait Any<T, B> {
 	}
 
 	#[inline]
-	fn language<'a>(&'a self) -> Option<&LenientLangTag>
+	fn language<'a>(&'a self) -> Option<&'a LenientLangTag>
 	where
 		T: 'a,
 		B: 'a,

--- a/crates/expansion/src/element.rs
+++ b/crates/expansion/src/element.rs
@@ -183,7 +183,7 @@ where
 						)
 						.await?
 						.into_processed(), // .err_at(|| active_property.as_ref().map(Meta::metadata).cloned().unwrap_or_default())?
-					                   // .into_inner(),
+					                    // .into_inner(),
 				);
 			}
 

--- a/crates/expansion/src/options.rs
+++ b/crates/expansion/src/options.rs
@@ -42,6 +42,7 @@ impl From<Options> for json_ld_context_processing::Options {
 /// is to drop keys that are not defined in the context unless:
 ///   - there is a vocabulary mapping (`@vocab`) defined in the context; or
 ///   - the term contains a `:` character.
+/// 
 /// In other words, a key that cannot be expanded into an
 /// IRI or a blank node identifier is dropped unless it contains a `:` character.
 ///

--- a/crates/expansion/src/options.rs
+++ b/crates/expansion/src/options.rs
@@ -42,7 +42,7 @@ impl From<Options> for json_ld_context_processing::Options {
 /// is to drop keys that are not defined in the context unless:
 ///   - there is a vocabulary mapping (`@vocab`) defined in the context; or
 ///   - the term contains a `:` character.
-/// 
+///
 /// In other words, a key that cannot be expanded into an
 /// IRI or a blank node identifier is dropped unless it contains a `:` character.
 ///

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -53,15 +53,17 @@ pub struct Options<I = IriBuf> {
 	/// to and from RDF.
 	///
 	///   - If set to [`RdfDirection::I18nDatatype`], an RDF literal is
-	/// generated using a datatype IRI based on <https://www.w3.org/ns/i18n#>
-	/// with both the language tag (if present) and base direction encoded. When
-	/// transforming from RDF, this datatype is decoded to create a value object
-	/// containing `@language` (if present) and `@direction`.
+	///     generated using a datatype IRI based on
+	///     <https://www.w3.org/ns/i18n#> with both the language tag (if
+	///     present) and base direction encoded. When transforming from RDF,
+	///     this datatype is decoded to create a value object containing
+	///     `@language` (if present) and `@direction`.
 	///   - If set to [`RdfDirection::CompoundLiteral`], a blank node is emitted
-	/// instead of a literal, where the blank node is the subject of
-	/// `rdf:value`, `rdf:direction`, and `rdf:language` (if present)
-	/// properties. When transforming from RDF, this object is decoded to create
-	/// a value object containing `@language` (if present) and `@direction`.
+	///     instead of a literal, where the blank node is the subject of
+	///     `rdf:value`, `rdf:direction`, and `rdf:language` (if present)
+	///     properties. When transforming from RDF, this object is decoded to
+	///     create a value object containing `@language` (if present) and
+	///     `@direction`.
 	pub rdf_direction: Option<RdfDirection>,
 
 	/// If set to `true`, the JSON-LD processor may emit blank nodes for triple


### PR DESCRIPTION
Currently JSON-LD through the `linked-data` crate tries to interpret typed string literals when serializing to RDF. A side effect is that each literal that is successfully interpreted will be serialized with its canonical representation, which might be different from the lexical representation found in the JSON-LD document. This behavior is unexpected, and differs from other JSON-LD processor implementations. This PR fixes that by not interpreting string literals.

Also fixes some formatting and clippy warnings, for Rust up to the version 1.81.0. For this reason I've also pinned the Rust version in the CI to 1.81.0.