### PR TITLE
patch for supporting the wasm32 target architecture

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -41,6 +41,9 @@ mime = "0.3"
 
 # For the reqwest loader
 reqwest = { version = "0.12", optional = true }
-reqwest-middleware = { version = "0.3", optional = true }
+#reqwest-middleware = { version = "0.3", optional = true }
 bytes = { version = "1.3", optional = true }
 utf8-decode = { version = "1.0.1", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+reqwest-middleware = { version = "0.3", optional = true }

--- a/crates/core/src/loader/reqwest/mod.rs
+++ b/crates/core/src/loader/reqwest/mod.rs
@@ -11,7 +11,6 @@ use reqwest::{
 	header::{ACCEPT, CONTENT_TYPE, LINK},
 	StatusCode,
 };
-use reqwest_middleware::ClientWithMiddleware;
 use std::string::FromUtf8Error;
 
 mod content_type;
@@ -38,8 +37,13 @@ pub struct Options {
 	/// [`client`](Self::client).
 	pub max_redirections: usize,
 
+	#[cfg(target_arch = "wasm32")]
 	/// HTTP client.
-	pub client: ClientWithMiddleware,
+	pub client: reqwest::Client,
+
+	#[cfg(not(target_arch = "wasm32"))]
+	/// HTTP client.
+	pub client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Default for Options {
@@ -47,7 +51,10 @@ impl Default for Options {
 		Self {
 			request_profile: Vec::new(),
 			max_redirections: 8,
+			#[cfg(not(target_arch = "wasm32"))]
 			client: reqwest_middleware::ClientBuilder::new(reqwest::Client::default()).build(),
+			#[cfg(target_arch = "wasm32")]
+			client: reqwest::Client::default(),
 		}
 	}
 }
@@ -55,8 +62,13 @@ impl Default for Options {
 /// Loading error.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+	#[cfg(not(target_arch = "wasm32"))]
 	#[error("internal error: {0}")]
 	Reqwest(reqwest_middleware::Error),
+
+	#[cfg(target_arch = "wasm32")]
+	#[error("internal error: {0}")]
+	Reqwest(reqwest::Error),
 
 	#[error("query failed: status code {0}")]
 	QueryFailed(StatusCode),


### PR DESCRIPTION
this patch is only required because reqwest-middleware currently does not compile in wasm32. See https://github.com/TrueLayer/reqwest-middleware/issues/276 Once that issue is fixed, this patch can be reverted.

In the meantime, what it does is replace the ClientWithMiddleware in loader::reqwest::Options with a simple reqwest::Client.

fix #90